### PR TITLE
Exclude tests from installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/alengwenus/pypck",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=("tests",)),
     install_requires=[],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Not generally desirable in the first place, and particularly not in the global `tests` top level package.