### PR TITLE
Add type annotations for mypy - Part 1

### DIFF
--- a/pypck/__init__.py
+++ b/pypck/__init__.py
@@ -20,4 +20,12 @@ from pypck import (
     timeout_retry,
 )
 
-__all__ = [connection, inputs, lcn_addr, lcn_defs, module, pck_commands, timeout_retry]
+__all__ = [
+    "connection",
+    "inputs",
+    "lcn_addr",
+    "lcn_defs",
+    "module",
+    "pck_commands",
+    "timeout_retry",
+]

--- a/pypck/inputs.py
+++ b/pypck/inputs.py
@@ -11,6 +11,7 @@ Contributors:
 """
 
 import logging
+from typing import List, Optional, Type
 
 from pypck import lcn_defs
 from pypck.lcn_addr import LcnAddr
@@ -28,16 +29,15 @@ class Input:
     Each Input object provides an implementation of
     :func:`~pypck.input.Input.try_parse` static method, to parse the given
     plain text PCK command. If the command can be parsed by the Input object,
-    a list of instances of :class:`~pypck.input.Input` is returned.
-    If parsing is successful, the :func:`~pypck.input.Input.process` method
-    can be called to trigger further actions.
+    a list of instances of :class:`~pypck.input.Input` is returned. Otherwise,
+    nothing is returned.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Construct Input object."""
 
     @staticmethod
-    def try_parse(data):
+    def try_parse(data: str) -> "Optional[List[Input]]":
         """Try to parse the given input text.
 
         Will return a list of parsed Inputs. The list might be empty (but not
@@ -45,7 +45,7 @@ class Input:
 
         :param    data    str:    The input data received from LCN-PCHK
 
-        :return:            The parsed Inputs (never null)
+        :return:            The parsed Inputs
         :rtype:             List with instances of :class:`~pypck.input.Input`
         """
         raise NotImplementedError
@@ -57,17 +57,17 @@ class ModInput(Input):
     The class in inherited from :class:`~pypck.input.Input`
     """
 
-    def __init__(self, physical_source_addr):
+    def __init__(self, physical_source_addr: LcnAddr):
         """Construct ModInput object."""
         super().__init__()
         self.physical_source_addr = physical_source_addr
         self.logical_source_addr = LcnAddr()
 
-    def get_logical_source_addr(self):
+    def get_logical_source_addr(self) -> LcnAddr:
         """Return the logical source id.
 
         :return:   Logical source address.
-        :rtype:    int
+        :rtype:    :class:`~pypck.lcn_addr.LcnAddr`
         """
         return self.logical_source_addr
 
@@ -79,7 +79,7 @@ class AuthUsername(Input):
     """Authentication username message received from PCHK."""
 
     @staticmethod
-    def try_parse(data):
+    def try_parse(data: str) -> Optional[List[Input]]:
         """Try to parse the given input text.
 
         Will return a list of parsed Inputs. The list might be empty (but not
@@ -87,18 +87,19 @@ class AuthUsername(Input):
 
         :param    data    str:    The input data received from LCN-PCHK
 
-        :return:            The parsed Inputs (never null)
+        :return:            The parsed Inputs
         :rtype:             List with instances of :class:`~pypck.input.Input`
         """
         if data == PckParser.AUTH_USERNAME:
             return [AuthUsername()]
+        return None
 
 
 class AuthPassword(Input):
     """Authentication password message received from PCHK."""
 
     @staticmethod
-    def try_parse(data):
+    def try_parse(data: str) -> Optional[List[Input]]:
         """Try to parse the given input text.
 
         Will return a list of parsed Inputs. The list might be empty (but not
@@ -106,18 +107,19 @@ class AuthPassword(Input):
 
         :param    data    str:    The input data received from LCN-PCHK
 
-        :return:            The parsed Inputs (never null)
+        :return:            The parsed Inputs
         :rtype:             List with instances of :class:`~pypck.input.Input`
         """
         if data == PckParser.AUTH_PASSWORD:
             return [AuthPassword()]
+        return None
 
 
 class AuthOk(Input):
     """Authentication ok message received from PCHK."""
 
     @staticmethod
-    def try_parse(data):
+    def try_parse(data: str) -> Optional[List[Input]]:
         """Try to parse the given input text.
 
         Will return a list of parsed Inputs. The list might be empty (but not
@@ -130,13 +132,14 @@ class AuthOk(Input):
         """
         if data == PckParser.AUTH_OK:
             return [AuthOk()]
+        return None
 
 
 class AuthFailed(Input):
     """Authentication failed message received from PCHK."""
 
     @staticmethod
-    def try_parse(data):
+    def try_parse(data: str) -> Optional[List[Input]]:
         """Try to parse the given input text.
 
         Will return a list of parsed Inputs. The list might be empty (but not
@@ -149,18 +152,19 @@ class AuthFailed(Input):
         """
         if data == PckParser.AUTH_FAILED:
             return [AuthFailed()]
+        return None
 
 
 class LcnConnState(Input):
     """LCN bus connected message received from PCHK."""
 
-    def __init__(self, is_lcn_connected):
+    def __init__(self, is_lcn_connected: bool):
         """Construct Input object."""
         super().__init__()
         self._is_lcn_connected = is_lcn_connected
 
     @property
-    def is_lcn_connected(self):
+    def is_lcn_connected(self) -> bool:
         """Return the LCN bus connection status.
 
         :return:   True if connection to hardware bus was established,
@@ -170,7 +174,7 @@ class LcnConnState(Input):
         return self._is_lcn_connected
 
     @staticmethod
-    def try_parse(data):
+    def try_parse(data: str) -> Optional[List[Input]]:
         """Try to parse the given input text.
 
         Will return a list of parsed Inputs. The list might be empty (but not
@@ -181,19 +185,18 @@ class LcnConnState(Input):
         :return:            The parsed Inputs (never null)
         :rtype:             List with instances of :class:`~pypck.input.Input`
         """
-        inputs = None
         if data == PckParser.LCNCONNSTATE_CONNECTED:
-            inputs = [LcnConnState(True)]
-        elif data == PckParser.LCNCONNSTATE_DISCONNECTED:
-            inputs = [LcnConnState(False)]
-        return inputs
+            return [LcnConnState(True)]
+        if data == PckParser.LCNCONNSTATE_DISCONNECTED:
+            return [LcnConnState(False)]
+        return None
 
 
 class LicenseError(Input):
     """LCN bus connected message received from PCHK."""
 
     @staticmethod
-    def try_parse(data):
+    def try_parse(data: str) -> Optional[List[Input]]:
         """Try to parse the given input text.
 
         Will return a list of parsed Inputs. The list might be empty (but not
@@ -206,13 +209,14 @@ class LicenseError(Input):
         """
         if data == PckParser.LICENSE_ERROR:
             return [LicenseError()]
+        return None
 
 
 class DecModeSet(Input):
     """Decimal mode set received from PCHK."""
 
     @staticmethod
-    def try_parse(data):
+    def try_parse(data: str) -> Optional[List[Input]]:
         """Try to parse the given input text.
 
         Will return a list of parsed Inputs. The list might be empty (but not
@@ -225,18 +229,19 @@ class DecModeSet(Input):
         """
         if data == PckParser.DEC_MODE_SET:
             return [DecModeSet()]
+        return None
 
 
 class CommandError(Input):
     """Command error received from PCHK."""
 
-    def __init__(self, message):
+    def __init__(self, message: str):
         """Construct Input object."""
         super().__init__()
         self.message = message
 
     @staticmethod
-    def try_parse(data):
+    def try_parse(data: str) -> Optional[List[Input]]:
         """Try to parse the given input text.
 
         Will return a list of parsed Inputs. The list might be empty (but not
@@ -250,6 +255,7 @@ class CommandError(Input):
         matcher = PckParser.PATTERN_COMMAND_ERROR.match(data)
         if matcher:
             return [CommandError(matcher.group("message"))]
+        return None
 
 
 # ## Inputs received from modules
@@ -258,12 +264,12 @@ class CommandError(Input):
 class ModAck(ModInput):
     """Acknowledge message received from module."""
 
-    def __init__(self, physical_source_addr, code):
+    def __init__(self, physical_source_addr: LcnAddr, code: int):
         """Construct ModInput object."""
         super().__init__(physical_source_addr)
         self.code = code
 
-    def get_code(self):
+    def get_code(self) -> int:
         """Return the acknowledge code.
 
         :return:    Acknowledge code.
@@ -272,7 +278,7 @@ class ModAck(ModInput):
         return self.code
 
     @staticmethod
-    def try_parse(data):
+    def try_parse(data: str) -> Optional[List[Input]]:
         """Try to parse the given input text.
 
         Will return a list of parsed Inputs. The list might be empty (but not
@@ -295,18 +301,20 @@ class ModAck(ModInput):
             addr = LcnAddr(
                 int(matcher_neg.group("seg_id")), int(matcher_neg.group("mod_id"))
             )
-            return [ModAck(addr, matcher_neg.group("code"))]
+            return [ModAck(addr, int(matcher_neg.group("code")))]
+
+        return None
 
 
 class ModSk(ModInput):
     """Segment information received from an LCN segment coupler."""
 
-    def __init__(self, physical_source_addr, reported_seg_id):
+    def __init__(self, physical_source_addr: LcnAddr, reported_seg_id: int):
         """Construct ModInput object."""
         super().__init__(physical_source_addr)
         self.reported_seg_id = reported_seg_id
 
-    def get_reported_seg_id(self):
+    def get_reported_seg_id(self) -> int:
         """Return the segment id reported from segment coupler.
 
         :return:   Reported segment id.
@@ -315,7 +323,7 @@ class ModSk(ModInput):
         return self.reported_seg_id
 
     @staticmethod
-    def try_parse(data):
+    def try_parse(data: str) -> Optional[List[Input]]:
         """Try to parse the given input text.
 
         Will return a list of parsed Inputs. The list might be empty (but not
@@ -331,11 +339,20 @@ class ModSk(ModInput):
             addr = LcnAddr(int(matcher.group("seg_id")), int(matcher.group("mod_id")))
             return [ModSk(addr, int(matcher.group("id")))]
 
+        return None
+
 
 class ModSn(ModInput):
     """Serial number and firmware version received from an LCN module."""
 
-    def __init__(self, physical_source_addr, serial, manu, sw_age, hw_type):
+    def __init__(
+        self,
+        physical_source_addr: LcnAddr,
+        serial: int,
+        manu: int,
+        sw_age: int,
+        hw_type: int,
+    ):
         """Construct ModInput object."""
         super().__init__(physical_source_addr)
         self.serial = serial
@@ -344,7 +361,7 @@ class ModSn(ModInput):
         self.hw_type = hw_type
 
     @staticmethod
-    def try_parse(data):
+    def try_parse(data: str) -> Optional[List[Input]]:
         """Try to parse the given input text.
 
         Will return a list of parsed Inputs. The list might be empty (but not
@@ -364,11 +381,15 @@ class ModSn(ModInput):
             hw_type = int(matcher.group("hw_type"))
             return [ModSn(addr, serial, manu, sw_age, hw_type)]
 
+        return None
+
 
 class ModNameComment(ModInput):
     """Name or comment received from an LCN module."""
 
-    def __init__(self, physical_source_addr, command, block_id, text):
+    def __init__(
+        self, physical_source_addr: LcnAddr, command: str, block_id: int, text: str
+    ):
         """Construct ModInput object."""
         super().__init__(physical_source_addr)
         self.command = command
@@ -376,7 +397,7 @@ class ModNameComment(ModInput):
         self.text = text
 
     @staticmethod
-    def try_parse(data):
+    def try_parse(data: str) -> Optional[List[Input]]:
         """Try to parse the given input text.
 
         Will return a list of parsed Inputs. The list might be empty (but not
@@ -395,17 +416,19 @@ class ModNameComment(ModInput):
             text = matcher.group("text")
             return [ModNameComment(addr, command, block_id, text)]
 
+        return None
+
 
 class ModStatusOutput(ModInput):
     """Status of an output-port received from an LCN module."""
 
-    def __init__(self, physical_source_addr, output_id, percent):
+    def __init__(self, physical_source_addr: LcnAddr, output_id: int, percent: float):
         """Construct ModInput object."""
         super().__init__(physical_source_addr)
         self.output_id = output_id
         self.percent = percent
 
-    def get_output_id(self):
+    def get_output_id(self) -> int:
         """Return the output port id.
 
         :return:    Output port id.
@@ -413,16 +436,16 @@ class ModStatusOutput(ModInput):
         """
         return self.output_id
 
-    def get_percent(self):
+    def get_percent(self) -> float:
         """Return the output brightness in percent.
 
         :return:    Brightness in percent.
-        :rtype:     int
+        :rtype:     float
         """
         return self.percent
 
     @staticmethod
-    def try_parse(data):
+    def try_parse(data: str) -> Optional[List[Input]]:
         """Try to parse the given input text.
 
         Will return a list of parsed Inputs. The list might be empty (but not
@@ -455,16 +478,18 @@ class ModStatusOutput(ModInput):
                 )
             ]
 
+        return None
+
 
 class ModStatusRelays(ModInput):
     """Status of 8 relays received from an LCN module."""
 
-    def __init__(self, physical_source_addr, states):
+    def __init__(self, physical_source_addr: LcnAddr, states: List[bool]):
         """Construct ModInput object."""
         super().__init__(physical_source_addr)
         self.states = states
 
-    def get_state(self, relay_id):
+    def get_state(self, relay_id: int) -> bool:
         """
         Get the state of a single relay.
 
@@ -476,7 +501,7 @@ class ModStatusRelays(ModInput):
         return self.states[relay_id]
 
     @staticmethod
-    def try_parse(data):
+    def try_parse(data: str) -> Optional[List[Input]]:
         """Try to parse the given input text.
 
         Will return a list of parsed Inputs. The list might be empty (but not
@@ -496,16 +521,18 @@ class ModStatusRelays(ModInput):
                 )
             ]
 
+        return None
+
 
 class ModStatusBinSensors(ModInput):
     """Status of 8 binary sensors received from an LCN module."""
 
-    def __init__(self, physical_source_addr, states):
+    def __init__(self, physical_source_addr: LcnAddr, states: List[bool]):
         """Construct ModInput object."""
         super().__init__(physical_source_addr)
         self.states = states
 
-    def get_state(self, bin_sensor_id):
+    def get_state(self, bin_sensor_id: int) -> bool:
         """Get the state of a single binary-sensor.
 
         :param    int    bin_sensor_id:    Binary sensor id (0..7)
@@ -516,7 +543,7 @@ class ModStatusBinSensors(ModInput):
         return self.states[bin_sensor_id]
 
     @staticmethod
-    def try_parse(data):
+    def try_parse(data: str) -> Optional[List[Input]]:
         """Try to parse the given input text.
 
         Will return a list of parsed Inputs. The list might be empty (but not
@@ -536,18 +563,25 @@ class ModStatusBinSensors(ModInput):
                 )
             ]
 
+        return None
+
 
 class ModStatusVar(ModInput):
     """Status of a variable received from an LCN module."""
 
-    def __init__(self, physical_source_addr, orig_var, value):
+    def __init__(
+        self,
+        physical_source_addr: LcnAddr,
+        orig_var: lcn_defs.Var,
+        value: lcn_defs.VarValue,
+    ):
         """Construct ModInput object."""
         super().__init__(physical_source_addr)
         self.orig_var = orig_var
         self.value = value
         self.var = self.orig_var
 
-    def get_var(self):
+    def get_var(self) -> lcn_defs.Var:
         """Get the variable's real type.
 
         :return:        The real type
@@ -555,7 +589,7 @@ class ModStatusVar(ModInput):
         """
         return self.var
 
-    def get_value(self):
+    def get_value(self) -> lcn_defs.VarValue:
         """Get the variable's value.
 
         :return:    The value of the variable.
@@ -564,7 +598,7 @@ class ModStatusVar(ModInput):
         return self.value
 
     @staticmethod
-    def try_parse(data):
+    def try_parse(data: str) -> Optional[List[Input]]:
         """Try to parse the given input text.
 
         Will return a list of parsed Inputs. The list might be empty (but not
@@ -614,7 +648,7 @@ class ModStatusVar(ModInput):
 
         matcher = PckParser.PATTERN_THRS5.match(data)
         if matcher:
-            ret = []
+            ret: List[Input] = []
             addr = LcnAddr(int(matcher.group("seg_id")), int(matcher.group("mod_id")))
             for thrs_id in range(5):
                 var = lcn_defs.Var.var_id_to_var(int(matcher.group("id")) - 1)
@@ -623,6 +657,8 @@ class ModStatusVar(ModInput):
                 )
                 ret.append(ModStatusVar(addr, var, value))
             return ret
+
+        return None
 
 
 class ModStatusLedsAndLogicOps(ModInput):
@@ -635,13 +671,18 @@ class ModStatusLedsAndLogicOps(ModInput):
     :type     states_logic_ops:   list(:class:`~pypck.lcn_defs.LogicOpStatus`)
     """
 
-    def __init__(self, physical_source_addr, states_led, states_logic_ops):
+    def __init__(
+        self,
+        physical_source_addr: LcnAddr,
+        states_led: List[lcn_defs.LedStatus],
+        states_logic_ops: List[lcn_defs.LogicOpStatus],
+    ):
         """Construct ModInput object."""
         super().__init__(physical_source_addr)
         self.states_led = states_led  # 12x LED status.
         self.states_logic_ops = states_logic_ops  # 4x logic-operation status.
 
-    def get_led_state(self, led_id):
+    def get_led_state(self, led_id: int) -> lcn_defs.LedStatus:
         """Get the status of a single LED.
 
         :param    int    led_id:   LED id (0..11)
@@ -650,7 +691,7 @@ class ModStatusLedsAndLogicOps(ModInput):
         """
         return self.states_led[led_id]
 
-    def get_logic_op_state(self, logic_op_id):
+    def get_logic_op_state(self, logic_op_id: int) -> lcn_defs.LogicOpStatus:
         """Get the status of a single logic operation.
 
         :param    int    logic_op_id:    Logic operation id (0..3)
@@ -660,7 +701,7 @@ class ModStatusLedsAndLogicOps(ModInput):
         return self.states_logic_ops[logic_op_id]
 
     @staticmethod
-    def try_parse(data):
+    def try_parse(data: str) -> Optional[List[Input]]:
         """Try to parse the given input text.
 
         Will return a list of parsed Inputs. The list might be empty (but not
@@ -685,6 +726,8 @@ class ModStatusLedsAndLogicOps(ModInput):
             ]
             return [ModStatusLedsAndLogicOps(addr, states_leds, states_logic_ops)]
 
+        return None
+
 
 class ModStatusKeyLocks(ModInput):
     """Status of locked keys received from an LCN module.
@@ -693,12 +736,12 @@ class ModStatusKeyLocks(ModInput):
     :param    list(list(bool))   states:               The 4x8 key-lock states
     """
 
-    def __init__(self, physical_source_id, states):
+    def __init__(self, physical_source_id: LcnAddr, states: List[List[bool]]):
         """Construct ModInput object."""
         super().__init__(physical_source_id)
         self.states = states
 
-    def get_state(self, table_id, key_id):
+    def get_state(self, table_id: int, key_id: int) -> bool:
         """Get the lock-state of a single key.
 
         :param    int    tableId:    Table id: (0..3  =>  A..D)
@@ -709,7 +752,7 @@ class ModStatusKeyLocks(ModInput):
         return self.states[table_id][key_id]
 
     @staticmethod
-    def try_parse(data):
+    def try_parse(data: str) -> Optional[List[Input]]:
         """Try to parse the given input text.
 
         Will return a list of parsed Inputs. The list might be empty (but not
@@ -721,7 +764,7 @@ class ModStatusKeyLocks(ModInput):
         :rtype:             List with instances of :class:`~pypck.input.Input`
         """
         matcher = PckParser.PATTERN_STATUS_KEYLOCKS.match(data)
-        states = []
+        states: List[List[bool]] = []
         if matcher:
             addr = LcnAddr(int(matcher.group("seg_id")), int(matcher.group("mod_id")))
             for i in range(4):
@@ -730,6 +773,8 @@ class ModStatusKeyLocks(ModInput):
                     states.append(PckParser.get_boolean_value(int(state)))
             return [ModStatusKeyLocks(addr, states)]
 
+        return None
+
 
 # ## Other inputs
 
@@ -737,13 +782,13 @@ class ModStatusKeyLocks(ModInput):
 class Unknown(Input):
     """Handle all unknown input data."""
 
-    def __init__(self, data):
+    def __init__(self, data: str):
         """Construct Input object."""
         super().__init__()
         self._data = data
 
     @staticmethod
-    def try_parse(data):
+    def try_parse(data: str) -> Optional[List[Input]]:
         """Try to parse the given input text.
 
         Will return a list of parsed Inputs. The list might be empty (but not
@@ -757,7 +802,7 @@ class Unknown(Input):
         return [Unknown(data)]
 
     @property
-    def data(self):
+    def data(self) -> str:
         """Return the received data.
 
         :return:    Received data.
@@ -769,7 +814,7 @@ class Unknown(Input):
 class InputParser:
     """Parse all input objects for given input data."""
 
-    parsers = [
+    parsers: List[Type[Input]] = [
         AuthUsername,
         AuthPassword,
         AuthOk,
@@ -792,7 +837,7 @@ class InputParser:
     ]
 
     @staticmethod
-    def parse(data):
+    def parse(data: str) -> Optional[List[Input]]:
         """Parse all input objects for given input data.
 
         :param    str    data:    The input data received from LCN-PCHK
@@ -801,6 +846,8 @@ class InputParser:
         :rtype:     List with instances of :class:`~pypck.input.Input`
         """
         for parser in InputParser.parsers:
-            ret = parser.try_parse(data)
+            ret: Optional[List[Input]] = parser.try_parse(data)
             if ret is not None:
                 return ret
+
+        return None

--- a/pypck/lcn_addr.py
+++ b/pypck/lcn_addr.py
@@ -47,13 +47,13 @@ class LcnAddr:
                                 5..254)
     """
 
-    def __init__(self, seg_id=-1, addr_id=-1, is_group=False):
+    def __init__(self, seg_id: int = -1, addr_id: int = -1, is_group: bool = False):
         """Construct LcnAddr instance."""
         self.seg_id = seg_id
         self.addr_id = addr_id
         self._is_group = is_group
 
-    def is_group(self):
+    def is_group(self) -> bool:
         """Get the address' module or group id (discarding the concrete type).
 
         :return:    Returns whether address points to a module(False) or
@@ -62,7 +62,7 @@ class LcnAddr:
         """
         return self._is_group
 
-    def get_seg_id(self):
+    def get_seg_id(self) -> int:
         """Get the logical segment id.
 
         :return:    The (logical) segment id
@@ -70,7 +70,7 @@ class LcnAddr:
         """
         return self.seg_id
 
-    def get_physical_seg_id(self, local_seg_id):
+    def get_physical_seg_id(self, local_seg_id: int) -> int:
         """Get the physical segment id ("local" segment replaced with 0).
 
         Can be used to send data into the LCN bus.
@@ -82,7 +82,7 @@ class LcnAddr:
         """
         return 0 if (self.seg_id == local_seg_id) else self.seg_id
 
-    def get_id(self):
+    def get_id(self) -> int:
         """Get the module id.
 
         :return:    The module id
@@ -90,7 +90,7 @@ class LcnAddr:
         """
         return self.addr_id
 
-    def is_valid(self):
+    def is_valid(self) -> bool:
         """Return if the current address is valid.
 
         :return:    True, if address is a valid group/module address,
@@ -126,7 +126,7 @@ class LcnAddr:
             )
         return is_valid
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         """Calculate and return hash value."""
         if self.is_valid():
             hash_value = (
@@ -138,12 +138,14 @@ class LcnAddr:
             hash_value = -1
         return hash_value
 
-    def __eq__(self, obj):
+    def __eq__(self, obj: object) -> bool:
         """Return if instance equals the given object."""
+        if not isinstance(obj, LcnAddr):
+            return False
         return (
             (self.is_group() == obj.is_group())
-            & (self.get_seg_id() == obj.get_seg_id())
-            & (self.get_id() == obj.get_id())
+            and (self.get_seg_id() == obj.get_seg_id())
+            and (self.get_id() == obj.get_id())
         )
 
 
@@ -156,7 +158,7 @@ if "REV_UINT8" not in dir():
                 REV_UINT8[i] |= 0x80 >> j
 
 
-def reverse_uint8(value):
+def reverse_uint8(value: int) -> int:
     """Reverse the bit order of the given value."""
     if value < 0 | value > 255:
         raise ValueError("Invalid value.")

--- a/pypck/lcn_defs.py
+++ b/pypck/lcn_defs.py
@@ -13,7 +13,6 @@ Contributors:
 import math
 import re
 from enum import Enum, auto
-from itertools import product
 
 LCN_ENCODING = "utf-8"
 PATTERN_SPLIT_PORT_PIN = re.compile(r"(?P<port>[a-zA-Z]+)(?P<pin>\d+)")
@@ -111,18 +110,44 @@ class BinSensorPort(Enum):
     BINSENSOR8 = 7
 
 
-# Keys
-# pylint: disable=invalid-name
-Key = Enum(
-    "Key",
-    " ".join(
-        [
-            "{:s}{:d}".format(t[0], t[1])
-            for t in product(["A", "B", "C", "D"], range(1, 9))
-        ]
-    ),
-    module=__name__,
-)
+class Key(Enum):
+    """Keys of LCN module."""
+
+    A1 = 0
+    A2 = 1
+    A3 = 2
+    A4 = 3
+    A5 = 4
+    A6 = 5
+    A7 = 6
+    A8 = 7
+
+    B1 = 8
+    B2 = 9
+    B3 = 10
+    B4 = 11
+    B5 = 12
+    B6 = 13
+    B7 = 14
+    B8 = 15
+
+    C1 = 16
+    C2 = 17
+    C3 = 18
+    C4 = 19
+    C5 = 20
+    C6 = 21
+    C7 = 22
+    C8 = 23
+
+    D1 = 24
+    D2 = 25
+    D3 = 26
+    D4 = 27
+    D5 = 28
+    D6 = 29
+    D7 = 30
+    D8 = 31
 
 
 class OutputPortDimMode(Enum):
@@ -194,6 +219,7 @@ def ramp_value_to_time(ramp_value):
     :returns: The ramp time in milliseconds.
     :rtype: int
     """
+    # pylint: disable=invalid-name
     if not 0 <= ramp_value <= 250:
         raise ValueError("Ramp value has to be in range 0..250.")
 
@@ -548,7 +574,7 @@ class Var(Enum):
 
 
 # Helper list to get var by numeric id.
-Var.variables = [
+Var.variables = [  # type: ignore
     Var.VAR1ORTVAR,
     Var.VAR2ORR1VAR,
     Var.VAR3ORR2VAR,
@@ -564,10 +590,10 @@ Var.variables = [
 ]
 
 # Helper list to get set-point var by numeric id.
-Var.set_points = [Var.R1VARSETPOINT, Var.R2VARSETPOINT]
+Var.set_points = [Var.R1VARSETPOINT, Var.R2VARSETPOINT]  # type: ignore
 
 # Helper list to get threshold var by numeric id.
-Var.thresholds = [
+Var.thresholds = [  # type: ignore
     [Var.THRS1, Var.THRS2, Var.THRS3, Var.THRS4, Var.THRS5],
     [Var.THRS2_1, Var.THRS2_2, Var.THRS2_3, Var.THRS2_4],
     [Var.THRS3_1, Var.THRS3_2, Var.THRS3_3, Var.THRS3_4],
@@ -575,7 +601,12 @@ Var.thresholds = [
 ]
 
 # Helper list to get S0-input var by numeric id.
-Var.s0s = [Var.S0INPUT1, Var.S0INPUT2, Var.S0INPUT3, Var.S0INPUT4]
+Var.s0s = [  # type: ignore
+    Var.S0INPUT1,
+    Var.S0INPUT2,
+    Var.S0INPUT3,
+    Var.S0INPUT4,
+]
 
 
 class VarUnit(Enum):
@@ -662,6 +693,7 @@ class VarValue:
         :return:    The variable value (never null)
         :rtype:    VarValue
         """
+        # pylint: disable=invalid-name
         if unit == VarUnit.NATIVE:
             var_value = VarValue.from_native(int(v))
         elif unit == VarUnit.CELSIUS:
@@ -699,6 +731,7 @@ class VarValue:
         :return:    The variable value (never null)
         :rtype:    VarValue
         """
+        # pylint: disable=invalid-name
         return VarValue(n)
 
     @staticmethod
@@ -713,6 +746,7 @@ class VarValue:
         :return:    The variable value (never null)
         :rtype:    VarValue
         """
+        # pylint: disable=invalid-name
         n = int(round(c * 10))
         return VarValue(n + 1000 if is_abs else n)
 
@@ -728,6 +762,7 @@ class VarValue:
         :return:    The variable value (never null)
         :rtype:    VarValue
         """
+        # pylint: disable=invalid-name
         if is_abs:
             k -= 273.15
 
@@ -746,6 +781,7 @@ class VarValue:
         :return:    The variable value (never null)
         :rtype:    VarValue
         """
+        # pylint: disable=invalid-name
         if is_abs:
             f -= 32
 
@@ -787,6 +823,7 @@ class VarValue:
         :return:    The variable value (never null)
         :rtype:    VarValue
         """
+        # pylint: disable=invalid-name
         return VarValue(int(round(p)))
 
     @staticmethod
@@ -800,6 +837,7 @@ class VarValue:
         :return:    The variable value (never null)
         :rtype:    VarValue
         """
+        # pylint: disable=invalid-name
         return VarValue(int(round(p)))
 
     @staticmethod
@@ -813,6 +851,7 @@ class VarValue:
         :return:    The variable value (never null)
         :rtype:    VarValue
         """
+        # pylint: disable=invalid-name
         return VarValue(int(round(ms * 10)))
 
     @staticmethod
@@ -824,6 +863,7 @@ class VarValue:
         :return:    The variable value (never null)
         :rtype:    VarValue
         """
+        # pylint: disable=invalid-name
         return VarValue(int(round(v * 400)))
 
     @staticmethod
@@ -835,6 +875,7 @@ class VarValue:
         :return: The variable value (never null)
         :rtype:    VarValue
         """
+        # pylint: disable=invalid-name
         return VarValue(int(round(a * 100)))
 
     @staticmethod
@@ -849,6 +890,7 @@ class VarValue:
         :return:    The variable value (never null)
         :rtype:     VarValue
         """
+        # pylint: disable=invalid-name
         n = int(round(d * 10))
         return VarValue(n + 1000 if is_abs else n)
 
@@ -861,6 +903,7 @@ class VarValue:
         :return:    The variable value
         :rtype:     VarValue
         """
+        # pylint: disable=invalid-name
         v = VarValue(
             self.native_value & 0x7FFF
             if is_lockable_regulator_source
@@ -1099,6 +1142,7 @@ class TimeUnit(Enum):
         :return:    TimeUnit enum
         :rtype:    TimeUnit
         """
+        # pylint: disable=invalid-name
         time_unit = time_unit.upper()
         if time_unit in ["SECONDS", "SECOND", "SEC", "S"]:
             tu = TimeUnit.SECONDS

--- a/pypck/lcn_defs.py
+++ b/pypck/lcn_defs.py
@@ -13,12 +13,13 @@ Contributors:
 import math
 import re
 from enum import Enum, auto
+from typing import Tuple, Union, Dict, Any
 
 LCN_ENCODING = "utf-8"
 PATTERN_SPLIT_PORT_PIN = re.compile(r"(?P<port>[a-zA-Z]+)(?P<pin>\d+)")
 
 
-def split_port_pin(portpin):
+def split_port_pin(portpin: str) -> Tuple[str, int]:
     """Split the port and the pin from the given input string.
 
     :param    str    portpin:    Input string
@@ -176,7 +177,7 @@ class OutputPortStatusMode(Enum):
     NATIVE = auto()  # 0..200 steps (since LCN-PCHK 2.3)
 
 
-def time_to_ramp_value(time_msec):
+def time_to_ramp_value(time_msec: int) -> int:
     """Convert the given time into an LCN ramp value.
 
     :param    int    time_msec:    The time in milliseconds.
@@ -205,13 +206,14 @@ def time_to_ramp_value(time_msec):
     elif time_msec < 6000:
         ret = 9
     else:
-        ret = (time_msec / 1000 - 6) / 2 + 10
-        if ret >= 250:
-            ret = 250
-    return int(ret)
+        ramp = (time_msec / 1000 - 6) / 2 + 10
+        if ramp >= 250:
+            ramp = 250
+        ret = int(ramp)
+    return ret
 
 
-def ramp_value_to_time(ramp_value):
+def ramp_value_to_time(ramp_value: int) -> int:
     """Convert the given LCN ramp value into a time.
 
     :param    int    ramp_value:    The LCN ramp value (0..250).
@@ -278,7 +280,7 @@ class Var(Enum):
     S0INPUT4 = auto()  # LCN-BU4LJVarValue
 
     @staticmethod
-    def var_id_to_var(var_id):
+    def var_id_to_var(var_id: int) -> "Var":
         """Translate a given id into a variable type.
 
         :param    int    varId:    The variable id (0..11)
@@ -286,12 +288,12 @@ class Var(Enum):
         :returns: The translated variable enum.
         :rtype: Var
         """
-        if (var_id < 0) or (var_id >= len(Var.variables)):
+        if (var_id < 0) or (var_id >= len(Var.variables)):  # type: ignore
             raise ValueError("Bad var_id.")
-        return Var.variables[var_id]
+        return Var.variables[var_id]  # type: ignore
 
     @staticmethod
-    def set_point_id_to_var(set_point_id):
+    def set_point_id_to_var(set_point_id: int) -> "Var":
         """Translate a given id into a LCN set-point variable type.
 
         :param     int    set_point_id:    Set-point id 0..1
@@ -299,12 +301,12 @@ class Var(Enum):
         :return: The translated var
         :rtype:  Var
         """
-        if (set_point_id < 0) or (set_point_id >= len(Var.set_points)):
+        if (set_point_id < 0) or (set_point_id >= len(Var.set_points)):  # type: ignore
             raise ValueError("Bad set_point_id.")
-        return Var.set_points[set_point_id]
+        return Var.set_points[set_point_id]  # type: ignore
 
     @staticmethod
-    def thrs_id_to_var(register_id, thrs_id):
+    def thrs_id_to_var(register_id: int, thrs_id: int) -> "Var":
         """Translate given ids into a LCN threshold variable type.
 
         :param    int    register_id:    Register id 0..3
@@ -316,15 +318,15 @@ class Var(Enum):
         """
         if (
             (register_id < 0)
-            or (register_id >= len(Var.thresholds))
+            or (register_id >= len(Var.thresholds))  # type: ignore
             or (thrs_id < 0)
             or (thrs_id >= (5 if (register_id == 0) else 4))
         ):
             raise ValueError("Bad register_id and/or thrs_id.")
-        return Var.thresholds[register_id][thrs_id]
+        return Var.thresholds[register_id][thrs_id]  # type: ignore
 
     @staticmethod
-    def s0_id_to_var(s0_id):
+    def s0_id_to_var(s0_id: int) -> "Var":
         """Translate a given id into a LCN S0-input variable type.
 
         :param     int    s0_id:     S0 id 0..3
@@ -332,12 +334,12 @@ class Var(Enum):
         :return:    The translated var
         :rtype:     Var
         """
-        if (s0_id < 0) or (s0_id >= len(Var.s0s)):
+        if (s0_id < 0) or (s0_id >= len(Var.s0s)):  # type: ignore
             raise ValueError("Bad s0_id.")
-        return Var.s0s[s0_id]
+        return Var.s0s[s0_id]  # type: ignore
 
     @staticmethod
-    def to_var_id(var):
+    def to_var_id(var: "Var") -> int:
         """Translate a given variable type into a variable id.
 
         :param     Var    var:    The variable type to translate
@@ -374,7 +376,7 @@ class Var(Enum):
         return var_id
 
     @staticmethod
-    def to_set_point_id(var):
+    def to_set_point_id(var: "Var") -> int:
         """Translate a given variable type into a set-point id.
 
         :param     Var    var:     The variable type to translate
@@ -391,7 +393,7 @@ class Var(Enum):
         return set_point_id
 
     @staticmethod
-    def to_thrs_register_id(var):
+    def to_thrs_register_id(var: "Var") -> int:
         """Translate a given variable type into a threshold register id.
 
         :param    Var    var:    The variable type to translate
@@ -412,7 +414,7 @@ class Var(Enum):
         return thrs_register_id
 
     @staticmethod
-    def to_thrs_id(var):
+    def to_thrs_id(var: "Var") -> int:
         """Translate a given variable type into a threshold id.
 
         :param    Var    var:    The variable type to translate
@@ -435,7 +437,7 @@ class Var(Enum):
         return thrs_id
 
     @staticmethod
-    def to_s0_id(var):
+    def to_s0_id(var: "Var") -> int:
         """Translate a given variable type into an S0-input id.
 
         :param    Var    var:    The variable type to translate
@@ -456,7 +458,7 @@ class Var(Enum):
         return s0_id
 
     @staticmethod
-    def is_lockable_regulator_source(var):
+    def is_lockable_regulator_source(var: "Var") -> bool:
         """Check if the the given variable type is lockable.
 
         :param    Var    var:    The variable type to check
@@ -467,7 +469,7 @@ class Var(Enum):
         return var in [Var.R1VARSETPOINT, Var.R2VARSETPOINT]
 
     @staticmethod
-    def use_lcn_special_values(var):
+    def use_lcn_special_values(var: "Var") -> bool:
         """Check if the given variable type uses special values.
 
         Examples for special values: 'No value yet', 'sensor defective' etc.
@@ -480,7 +482,7 @@ class Var(Enum):
         return var not in [Var.S0INPUT1, Var.S0INPUT2, Var.S0INPUT3, Var.S0INPUT4]
 
     @staticmethod
-    def has_type_in_response(var, sw_age):
+    def has_type_in_response(var: "Var", sw_age: int) -> bool:
         """Module-generation check.
 
         Check if the given variable type would receive a typed response if
@@ -505,7 +507,7 @@ class Var(Enum):
         return True
 
     @staticmethod
-    def is_event_based(var, sw_age):
+    def is_event_based(var: "Var", sw_age: int) -> bool:
         """Module-generation check.
 
         Check if the given variable type automatically sends status-updates
@@ -523,7 +525,7 @@ class Var(Enum):
         return sw_age >= 0x170206
 
     @staticmethod
-    def should_poll_status_after_command(var, is2013):
+    def should_poll_status_after_command(var: "Var", is2013: bool) -> bool:
         """Module-generation check.
 
         Check if the target LCN module would automatically send status-updates
@@ -542,7 +544,7 @@ class Var(Enum):
             return False
 
         # Thresholds since 170206 will send status-messages on every change
-        if is2013 and (Var.to_thrs_register_id(var != -1)):
+        if is2013 and (Var.to_thrs_register_id(var) != -1):
             return False
 
         # Others:
@@ -555,7 +557,7 @@ class Var(Enum):
         return True
 
     @staticmethod
-    def should_poll_status_after_regulator_lock(sw_age, lock_state):
+    def should_poll_status_after_regulator_lock(sw_age: int, lock_state: int) -> bool:
         """Module-generation check.
 
         Check if the target LCN module would automatically send status-updates
@@ -626,7 +628,7 @@ class VarUnit(Enum):
     DEGREE = u"\u00b0"  # Used for angles,
 
     @staticmethod
-    def parse(unit):
+    def parse(unit: str) -> "VarUnit":
         """Parse the given unit string and return VarUnit.
 
         :param    str    unit:    The input unit
@@ -672,16 +674,16 @@ class VarValue:
     :param    int    native_value:    The native value
     """
 
-    def __init__(self, native_value):
+    def __init__(self, native_value: int):
         """Construct with native LCN value."""
         self.native_value = native_value
 
-    def is_locked_regulator(self):
+    def is_locked_regulator(self) -> bool:
         """Return if regulator is locked."""
         return (self.native_value & 0x8000) != 0
 
     @staticmethod
-    def from_var_unit(v, unit, is_abs):
+    def from_var_unit(v: float, unit: VarUnit, is_abs: bool) -> "VarValue":
         """Create a variable value from any input.
 
         :param    float    v:       The input value
@@ -723,7 +725,7 @@ class VarValue:
         return var_value
 
     @staticmethod
-    def from_native(n):
+    def from_native(n: int) -> "VarValue":
         """Create a variable value from native input.
 
         :param    int    n:    The input value
@@ -735,7 +737,7 @@ class VarValue:
         return VarValue(n)
 
     @staticmethod
-    def from_celsius(c, is_abs=True):
+    def from_celsius(c: float, is_abs: bool = True) -> "VarValue":
         """Create a variable value from Celsius input.
 
         :param    float    c:        The input value
@@ -751,7 +753,7 @@ class VarValue:
         return VarValue(n + 1000 if is_abs else n)
 
     @staticmethod
-    def from_kelvin(k, is_abs=True):
+    def from_kelvin(k: float, is_abs: bool = True) -> "VarValue":
         """Create a variable value from Kelvin input.
 
         :param    float    k:        The input value
@@ -770,7 +772,7 @@ class VarValue:
         return VarValue(n + 1000 if is_abs else n)
 
     @staticmethod
-    def from_fahrenheit(f, is_abs=True):
+    def from_fahrenheit(f: float, is_abs: bool = True) -> "VarValue":
         """Create a variable value from Fahrenheit input.
 
         :param    float    f:        The input value
@@ -789,7 +791,7 @@ class VarValue:
         return VarValue(n + 1000 if is_abs else n)
 
     @staticmethod
-    def from_lux_t(lux):
+    def from_lux_t(lux: float) -> "VarValue":
         """Create a variable value from lx input.
 
         Target must be connected to T-port.
@@ -802,7 +804,7 @@ class VarValue:
         return VarValue(int(round(math.log(lux) - 1.689646994) / 0.010380664))
 
     @staticmethod
-    def from_lux_i(lux):
+    def from_lux_i(lux: float) -> "VarValue":
         """Create a variable value from lx input.
 
         Target must be connected to I-port.
@@ -815,7 +817,7 @@ class VarValue:
         return VarValue(int(round(math.log(lux) * 100)))
 
     @staticmethod
-    def from_percent(p):
+    def from_percent(p: float) -> "VarValue":
         """Create a variable value from % input.
 
         :param    float    p:    The input value
@@ -827,7 +829,7 @@ class VarValue:
         return VarValue(int(round(p)))
 
     @staticmethod
-    def from_ppm(p):
+    def from_ppm(p: float) -> "VarValue":
         """Create a variable value from ppm input.
 
         Used for CO2 sensors.
@@ -841,7 +843,7 @@ class VarValue:
         return VarValue(int(round(p)))
 
     @staticmethod
-    def from_meters_per_second(ms):
+    def from_meters_per_second(ms: float) -> "VarValue":
         """Create a variable value from m/s input.
 
         Used for LCN-WIH wind speed.
@@ -855,7 +857,7 @@ class VarValue:
         return VarValue(int(round(ms * 10)))
 
     @staticmethod
-    def from_volt(v):
+    def from_volt(v: float) -> "VarValue":
         """Create a variable value from V input.
 
         :param    float    v:    The input value
@@ -867,7 +869,7 @@ class VarValue:
         return VarValue(int(round(v * 400)))
 
     @staticmethod
-    def from_ampere(a):
+    def from_ampere(a: float) -> "VarValue":
         """Create a variable value from A input.
 
         :param    float    a:    The input value
@@ -879,7 +881,7 @@ class VarValue:
         return VarValue(int(round(a * 100)))
 
     @staticmethod
-    def from_degree(d, is_abs=True):
+    def from_degree(d: float, is_abs: bool = True) -> "VarValue":
         """Create a variable value from degree (angle) input.
 
         :param    float    d:        The input value
@@ -894,14 +896,16 @@ class VarValue:
         n = int(round(d * 10))
         return VarValue(n + 1000 if is_abs else n)
 
-    def to_var_unit(self, unit, is_lockable_regulator_source=False):
+    def to_var_unit(
+        self, unit: VarUnit, is_lockable_regulator_source: bool = False
+    ) -> Union[int, float]:
         """Convert the given unit to a VarValue.
 
         :param    VarUnit    unit:    The variable unit
         :param    bool       is_lockable_regulator_source:  Is lockable source
 
         :return:    The variable value
-        :rtype:     VarValue
+        :rtype:     Union[int,float]
         """
         # pylint: disable=invalid-name
         v = VarValue(
@@ -911,34 +915,32 @@ class VarValue:
         )
 
         if unit == VarUnit.NATIVE:
-            var_value = v.to_native()
-        elif unit == VarUnit.CELSIUS:
-            var_value = v.to_celsius()
-        elif unit == VarUnit.KELVIN:
-            var_value = v.to_kelvin()
-        elif unit == VarUnit.FAHRENHEIT:
-            var_value = v.to_fahrenheit()
-        elif unit == VarUnit.LUX_T:
-            var_value = v.to_lux_t()
-        elif unit == VarUnit.LUX_I:
-            var_value = v.to_lux_i()
-        elif unit == VarUnit.METERPERSECOND:
-            var_value = v.to_meters_per_second()
-        elif unit == VarUnit.PERCENT:
-            var_value = v.to_percent()
-        elif unit == VarUnit.PPM:
-            var_value = v.to_ppm()
-        elif unit == VarUnit.VOLT:
-            var_value = v.to_volt()
-        elif unit == VarUnit.AMPERE:
-            var_value = v.to_ampere()
-        elif unit == VarUnit.DEGREE:
-            var_value = v.to_degree()
-        else:
-            raise ValueError("Wrong unit.")
-        return var_value
+            return v.to_native()
+        if unit == VarUnit.CELSIUS:
+            return v.to_celsius()
+        if unit == VarUnit.KELVIN:
+            return v.to_kelvin()
+        if unit == VarUnit.FAHRENHEIT:
+            return v.to_fahrenheit()
+        if unit == VarUnit.LUX_T:
+            return v.to_lux_t()
+        if unit == VarUnit.LUX_I:
+            return v.to_lux_i()
+        if unit == VarUnit.METERPERSECOND:
+            return v.to_meters_per_second()
+        if unit == VarUnit.PERCENT:
+            return v.to_percent()
+        if unit == VarUnit.PPM:
+            return v.to_ppm()
+        if unit == VarUnit.VOLT:
+            return v.to_volt()
+        if unit == VarUnit.AMPERE:
+            return v.to_ampere()
+        if unit == VarUnit.DEGREE:
+            return v.to_degree()
+        raise ValueError("Wrong unit.")
 
-    def to_native(self):
+    def to_native(self) -> int:
         """Convert to native value.
 
         :return:    The converted value
@@ -946,7 +948,7 @@ class VarValue:
         """
         return self.native_value
 
-    def to_celsius(self):
+    def to_celsius(self) -> float:
         """Convert to Celsius value.
 
         :return:    The converted value
@@ -954,7 +956,7 @@ class VarValue:
         """
         return (self.native_value - 1000) / 10.0
 
-    def to_kelvin(self):
+    def to_kelvin(self) -> float:
         """Convert to Kelvin value.
 
         :return:    The converted value
@@ -962,7 +964,7 @@ class VarValue:
         """
         return (self.native_value - 1000) / 10.0 + 273.15
 
-    def to_fahrenheit(self):
+    def to_fahrenheit(self) -> float:
         """Convert to Fahrenheit value.
 
         :return:    The converted value
@@ -970,7 +972,7 @@ class VarValue:
         """
         return (self.native_value - 1000) * 0.18 + 32.0
 
-    def to_lux_t(self):
+    def to_lux_t(self) -> float:
         """Convert to lx value.
 
         Source must be connected to T-port.
@@ -980,7 +982,7 @@ class VarValue:
         """
         return math.exp(0.010380664 * self.native_value + 1.689646994)
 
-    def to_lux_i(self):
+    def to_lux_i(self) -> float:
         """Convert to lx value.
 
         Source must be connected to I-port.
@@ -990,7 +992,7 @@ class VarValue:
         """
         return math.exp(self.native_value / 100)
 
-    def to_percent(self):
+    def to_percent(self) -> int:
         """Convert to % value.
 
         :return:    The converted value
@@ -998,7 +1000,7 @@ class VarValue:
         """
         return self.native_value
 
-    def to_ppm(self):
+    def to_ppm(self) -> int:
         """Convert to ppm value.
 
         :return:    The converted value
@@ -1006,7 +1008,7 @@ class VarValue:
         """
         return self.native_value
 
-    def to_meters_per_second(self):
+    def to_meters_per_second(self) -> float:
         """Convert to m/s value.
 
         :return:    The converted value
@@ -1014,7 +1016,7 @@ class VarValue:
         """
         return self.native_value / 10.0
 
-    def to_volt(self):
+    def to_volt(self) -> float:
         """Convert to V value.
 
         :return:    The converted value
@@ -1022,7 +1024,7 @@ class VarValue:
         """
         return self.native_value / 400.0
 
-    def to_ampere(self):
+    def to_ampere(self) -> float:
         """Convert to A value.
 
         :return:    The converted value
@@ -1030,7 +1032,7 @@ class VarValue:
         """
         return self.native_value / 100.0
 
-    def to_degree(self):
+    def to_degree(self) -> float:
         """Convert to degree value.
 
         :return:    The converted value
@@ -1039,8 +1041,11 @@ class VarValue:
         return (self.native_value - 1000) / 10.0
 
     def to_var_unit_string(
-        self, unit, is_lockable_regulator_source=False, use_lcn_special_values=False
-    ):
+        self,
+        unit: VarUnit,
+        is_lockable_regulator_source: bool = False,
+        use_lcn_special_values: bool = False,
+    ) -> str:
         """Convert the given unit into a string representation.
 
         :param    VarUnit    unit:    The input unit
@@ -1132,7 +1137,7 @@ class TimeUnit(Enum):
     DAYS = "D"
 
     @staticmethod
-    def parse(time_unit):
+    def parse(time_unit: str) -> "TimeUnit":
         """Parse the given time_unit into a time unit.
 
         It supports several alternative terms.
@@ -1217,7 +1222,7 @@ class KeyLockStateModifier(Enum):
     NOCHANGE = "-"
 
 
-default_connection_settings = {
+default_connection_settings: Dict[str, Any] = {
     "NUM_TRIES": 3,  # Total number of request to sent before going into
     # failed-state.
     "SK_NUM_TRIES": 3,  # Total number of segment coupler scan tries

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, lint, pylint, cov
+envlist = py37, py38, lint, pylint, mypy, cov
 skip_missing_interpreters = True
 
 [testenv]
@@ -32,6 +32,12 @@ deps =
 commands =
     flake8 {posargs:pypck}
     pydocstyle {posargs:pypck}
+
+[testenv:mypy]
+deps =
+    mypy
+commands =
+    mypy {posargs:pypck}
 
 
 [pytest]


### PR DESCRIPTION
Issue #10 

Add type annotations to all pypck files except module.py and connection.py. mypy --strict is warning/error-free on all files except those two.  Add an additonal stage for mypy (not yet strict). I intend to switch it to strict once all files have complete type annotations.

The two missing files turn out to be more work than expected since they are pretty dependent on each other. For example, full type annotations in module.py require an additional import of connection.py, which already imports module.py. It might be a good idea regardless of type annotations to break this circular dependency. So I did split those two off from this PR for now.

@alengwenus  Please let me know what you think. Thanks!