### PR TITLE
Add type annotations - part 2

### DIFF
--- a/pypck/module.py
+++ b/pypck/module.py
@@ -13,7 +13,6 @@ Contributors:
 import asyncio
 from asyncio import Task
 from collections import deque
-import typing
 from typing import (
     TYPE_CHECKING,
     Optional,
@@ -489,7 +488,6 @@ class StatusRequestsHandler:
         if not failed:
             self.addr_conn.send_command(False, PckGenerator.request_key_lock_status())
 
-    @typing.no_type_check
     async def activate(self, item: Any) -> None:
         """Activate status requests for given item."""
         await self.addr_conn.conn.segment_scan_completed_event.wait()
@@ -516,7 +514,6 @@ class StatusRequestsHandler:
         elif item in lcn_defs.Key:
             self.request_status_locked_keys.activate()
 
-    @typing.no_type_check
     async def cancel(self, item: Any) -> None:
         """Cancel status request for given item."""
         # handle variables independently

--- a/pypck/module.py
+++ b/pypck/module.py
@@ -11,18 +11,42 @@ Contributors:
 """
 
 import asyncio
+from asyncio import Task
 from collections import deque
+import typing
+from typing import (
+    TYPE_CHECKING,
+    Optional,
+    Dict,
+    Tuple,
+    List,
+    Any,
+    Callable,
+    Sequence,
+    Union,
+    Deque,
+    Awaitable,
+)
 
 from pypck import inputs, lcn_defs
 from pypck.lcn_addr import LcnAddr
 from pypck.pck_commands import PckGenerator
 from pypck.timeout_retry import DEFAULT_TIMEOUT_MSEC, TimeoutRetryHandler
 
+if TYPE_CHECKING:
+    from pypck.connection import PchkConnectionManager
+
 
 class SerialRequestHandler:
     """Request handler to request serial number information from module."""
 
-    def __init__(self, addr_conn, num_tries=3, timeout_msec=1500, software_serial=None):
+    def __init__(
+        self,
+        addr_conn: "ModuleConnection",
+        num_tries: int = 3,
+        timeout_msec: int = 1500,
+        software_serial: Optional[int] = None,
+    ):
         """Initialize class instance."""
         self.addr_conn = addr_conn
 
@@ -43,11 +67,11 @@ class SerialRequestHandler:
         # events
         self.serial_known = asyncio.Event()
 
-    def process_input(self, inp):
+    def process_input(self, inp: inputs.Input) -> None:
         """Create a task to process the input object concurrently."""
         asyncio.create_task(self.async_process_input(inp))
 
-    async def async_process_input(self, inp):
+    async def async_process_input(self, inp: inputs.Input) -> None:
         """Process incoming input object.
 
         Method to handle incoming commands for this specific request handler.
@@ -63,14 +87,14 @@ class SerialRequestHandler:
 
             await self.cancel()
 
-    def timeout(self, failed=False):
+    def timeout(self, failed: bool = False) -> None:
         """Is called on serial request timeout."""
         if not failed:
             self.addr_conn.send_command(False, PckGenerator.request_serial())
         else:
             self.serial_known.set()
 
-    async def request(self):
+    async def request(self) -> Dict[str, int]:
         """Request serial number."""
         await self.addr_conn.conn.segment_scan_completed_event.wait()
         self.serial_known.clear()
@@ -78,12 +102,12 @@ class SerialRequestHandler:
         await self.serial_known.wait()
         return self.serial
 
-    async def cancel(self):
+    async def cancel(self) -> None:
         """Cancel serial number request."""
         await self.trh.cancel()
 
     @property
-    def serial(self):
+    def serial(self) -> Dict[str, int]:
         """Return serial numbers of a module."""
         return {
             "hardware_serial": self.hardware_serial,
@@ -96,13 +120,18 @@ class SerialRequestHandler:
 class NameCommentRequestHandler:
     """Request handler to request name, comment and OEM text of a module."""
 
-    def __init__(self, addr_conn, num_tries=3, timeout_msec=1500):
+    def __init__(
+        self,
+        addr_conn: "ModuleConnection",
+        num_tries: int = 3,
+        timeout_msec: int = 1500,
+    ):
         """Initialize class instance."""
         self.addr_conn = addr_conn
 
-        self._name = [None] * 2
-        self._comment = [None] * 3
-        self._oem_text = [None] * 4
+        self._name: List[Optional[str]] = [None] * 2
+        self._comment: List[Optional[str]] = [None] * 3
+        self._oem_text: List[Optional[str]] = [None] * 4
 
         # Name requests
         self.name_trhs = []
@@ -131,11 +160,11 @@ class NameCommentRequestHandler:
         self.comment_known = asyncio.Event()
         self.oem_text_known = asyncio.Event()
 
-    def process_input(self, inp):
+    def process_input(self, inp: inputs.Input) -> None:
         """Create a task to process the input object concurrently."""
         asyncio.create_task(self.async_process_input(inp))
 
-    async def async_process_input(self, inp):
+    async def async_process_input(self, inp: inputs.Input) -> None:
         """Process incoming input object.
 
         Method to handle incoming commands for this specific request handler.
@@ -166,28 +195,28 @@ class NameCommentRequestHandler:
                     self.oem_text_known.set()
                     await self.cancel_oem_text()
 
-    def timeout_name(self, failed=False, block_id=0):
+    def timeout_name(self, failed: bool = False, block_id: int = 0) -> None:
         """Is called on serial request timeout."""
         if not failed:
             self.addr_conn.send_command(False, PckGenerator.request_name(block_id))
         else:
             self.name_known.set()
 
-    def timeout_comment(self, failed=False, block_id=0):
+    def timeout_comment(self, failed: bool = False, block_id: int = 0) -> None:
         """Is called on serial request timeout."""
         if not failed:
             self.addr_conn.send_command(False, PckGenerator.request_comment(block_id))
         else:
             self.comment_known.set()
 
-    def timeout_oem_text(self, failed=False, block_id=0):
+    def timeout_oem_text(self, failed: bool = False, block_id: int = 0) -> None:
         """Is called on serial request timeout."""
         if not failed:
             self.addr_conn.send_command(False, PckGenerator.request_oem_text(block_id))
         else:
             self.oem_text_known.set()
 
-    async def request_name(self):
+    async def request_name(self) -> str:
         """Request name from a module."""
         self._name = [None] * 2
         await self.addr_conn.conn.segment_scan_completed_event.wait()
@@ -197,7 +226,7 @@ class NameCommentRequestHandler:
         await self.name_known.wait()
         return self.name
 
-    async def request_comment(self):
+    async def request_comment(self) -> str:
         """Request comments from a module."""
         self._comment = [None] * 3
         await self.addr_conn.conn.segment_scan_completed_event.wait()
@@ -207,7 +236,7 @@ class NameCommentRequestHandler:
         await self.comment_known.wait()
         return self.comment
 
-    async def request_oem_text(self):
+    async def request_oem_text(self) -> List[str]:
         """Request OEM text from a module."""
         self._oem_text = [None] * 4
         await self.addr_conn.conn.segment_scan_completed_event.wait()
@@ -217,13 +246,13 @@ class NameCommentRequestHandler:
         await self.oem_text_known.wait()
         return self.oem_text
 
-    async def request(self):
+    async def request(self) -> Tuple[str, str, List[str]]:
         """Request name, comments and OEM text from a module."""
         return await asyncio.gather(
             self.request_name(), self.request_comment(), self.request_oem_text()
         )
 
-    async def cancel_name(self, block_id=None):
+    async def cancel_name(self, block_id: Optional[int] = None) -> None:
         """Cancel name request task."""
         if block_id is None:  # cancel all
             for trh in self.name_trhs:
@@ -231,7 +260,7 @@ class NameCommentRequestHandler:
         else:
             await self.name_trhs[block_id].cancel()
 
-    async def cancel_comment(self, block_id=None):
+    async def cancel_comment(self, block_id: Optional[int] = None) -> None:
         """Cancel comment request task."""
         if block_id is None:  # cancel all
             for trh in self.comment_trhs:
@@ -239,7 +268,7 @@ class NameCommentRequestHandler:
         else:
             await self.comment_trhs[block_id].cancel()
 
-    async def cancel_oem_text(self, block_id=None):
+    async def cancel_oem_text(self, block_id: Optional[int] = None) -> None:
         """Cancel OEM text request task."""
         if block_id is None:  # cancel all
             for trh in self.oem_text_trhs:
@@ -247,24 +276,24 @@ class NameCommentRequestHandler:
         else:
             await self.oem_text_trhs[block_id].cancel()
 
-    async def cancel(self):
+    async def cancel(self) -> None:
         """Cancel all name, comment and OEM text request tasks."""
         await asyncio.gather(
             self.cancel_name(), self.cancel_comment(), self.cancel_oem_text()
         )
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return stored name."""
         return "".join([block for block in self._name if block]).strip()
 
     @property
-    def comment(self):
+    def comment(self) -> str:
         """Return stored comment."""
         return "".join([block for block in self._comment if block]).strip()
 
     @property
-    def oem_text(self):
+    def oem_text(self) -> List[str]:
         """Return stored OEM text."""
         return [block.strip() if block else "" for block in self._oem_text]
         # return {'block{}'.format(idx):text
@@ -276,39 +305,48 @@ class NameCommentRequestHandler:
 class ModulePropertiesRequestHandler:
     """Manages all property requestst for serial number, name, comments, ..."""
 
-    def __init__(self, addr_conn, software_serial=None):
+    def __init__(
+        self, addr_conn: "ModuleConnection", software_serial: Optional[int] = None
+    ):
         """Construct ModulePropertiesRequestHandler."""
         self.addr_conn = addr_conn
         self.settings = addr_conn.conn.settings
 
-        self.serial_request_task = None
+        self.serial_request_task: Optional[Task[Dict[str, int]]] = None
+
+        num_tries: int = self.settings["NUM_TRIES"]
+        timeout_msec: int = self.settings["DEFAULT_TIMEOUT_MSEC"]
 
         # Serial Number request
         self.serials = SerialRequestHandler(
             addr_conn,
-            self.settings["NUM_TRIES"],
-            timeout_msec=self.settings["DEFAULT_TIMEOUT_MSEC"],
+            num_tries,
+            timeout_msec=timeout_msec,
             software_serial=software_serial,
         )
 
         # NameComment request
         self.name_comment = NameCommentRequestHandler(
             addr_conn,
-            self.settings["NUM_TRIES"],
-            timeout_msec=self.settings["DEFAULT_TIMEOUT_MSEC"],
+            num_tries,
+            timeout_msec=timeout_msec,
         )
 
-    async def activate_all(self):
+    async def activate_all(self) -> None:
         """Activate all properties requests."""
         # software_serial is not given externally
         await self.addr_conn.conn.segment_scan_completed_event.wait()
         if self.serials.software_serial == -1:
             self.serial_request_task = asyncio.create_task(self.serials.request())
 
-    async def cancel_all(self):
+    async def cancel_all(self) -> None:
         """Cancel all properties requests."""
-        self.serial_request_task.cancel()
-        await self.serial_request_task
+        if self.serial_request_task is not None:
+            self.serial_request_task.cancel()
+            try:
+                await self.serial_request_task
+            except asyncio.CancelledError:
+                pass
         await self.serials.cancel()
         await self.name_comment.cancel()
 
@@ -316,7 +354,7 @@ class ModulePropertiesRequestHandler:
 class StatusRequestsHandler:
     """Manages all status requests for variables, software version, ..."""
 
-    def __init__(self, addr_conn):
+    def __init__(self, addr_conn: "ModuleConnection"):
         """Construct StatusRequestHandler instance."""
         self.addr_conn = addr_conn
         self.settings = addr_conn.conn.settings
@@ -378,7 +416,7 @@ class StatusRequestsHandler:
             self.request_status_locked_keys_timeout
         )
 
-    def preprocess_modstatusvar(self, inp):
+    def preprocess_modstatusvar(self, inp: inputs.ModStatusVar) -> inputs.Input:
         """Fill typeless response with last requested variable type."""
         if inp.orig_var == lcn_defs.Var.UNKNOWN:
             # Response without type (%Msssaaa.wwwww)
@@ -394,27 +432,32 @@ class StatusRequestsHandler:
 
         return inp
 
-    def request_status_outputs_timeout(self, failed=False, output_port=0):
+    def request_status_outputs_timeout(
+        self, failed: bool = False, output_port: int = 0
+    ) -> None:
         """Is called on output status request timeout."""
         if not failed:
             self.addr_conn.send_command(
                 False, PckGenerator.request_output_status(output_port)
             )
 
-    def request_status_relays_timeout(self, failed=False):
+    def request_status_relays_timeout(self, failed: bool = False) -> None:
         """Is called on relay status request timeout."""
         if not failed:
             self.addr_conn.send_command(False, PckGenerator.request_relays_status())
 
-    def request_status_bin_sensors_timeout(self, failed=False):
+    def request_status_bin_sensors_timeout(self, failed: bool = False) -> None:
         """Is called on binary sensor status request timeout."""
         if not failed:
             self.addr_conn.send_command(
                 False, PckGenerator.request_bin_sensors_status()
             )
 
-    async def request_status_var_timeout(self, failed=False, var=None):
+    async def request_status_var_timeout(
+        self, failed: bool = False, var: Optional[lcn_defs.Var] = None
+    ) -> None:
         """Is called on variable status request timeout."""
+        assert var is not None
         # Detect if we can send immediately or if we have to wait for a
         # "typeless" response first
         has_type_in_response = lcn_defs.Var.has_type_in_response(
@@ -434,19 +477,20 @@ class StatusRequestsHandler:
             PckGenerator.request_var_status(var, self.addr_conn.software_serial),
         )
 
-    def request_status_leds_and_logic_ops_timeout(self, failed=False):
+    def request_status_leds_and_logic_ops_timeout(self, failed: bool = False) -> None:
         """Is called on leds/logical ops status request timeout."""
         if not failed:
             self.addr_conn.send_command(
                 False, PckGenerator.request_leds_and_logic_ops()
             )
 
-    def request_status_locked_keys_timeout(self, failed=False):
+    def request_status_locked_keys_timeout(self, failed: bool = False) -> None:
         """Is called on locked keys status request timeout."""
         if not failed:
             self.addr_conn.send_command(False, PckGenerator.request_key_lock_status())
 
-    async def activate(self, item):
+    @typing.no_type_check
+    async def activate(self, item: Any) -> None:
         """Activate status requests for given item."""
         await self.addr_conn.conn.segment_scan_completed_event.wait()
         # handle variables independently
@@ -472,7 +516,8 @@ class StatusRequestsHandler:
         elif item in lcn_defs.Key:
             self.request_status_locked_keys.activate()
 
-    async def cancel(self, item):
+    @typing.no_type_check
+    async def cancel(self, item: Any) -> None:
         """Cancel status request for given item."""
         # handle variables independently
         if (item in lcn_defs.Var) and (item != lcn_defs.Var.UNKNOWN):
@@ -491,9 +536,9 @@ class StatusRequestsHandler:
         elif item in lcn_defs.Key:
             await self.request_status_locked_keys.cancel()
 
-    async def activate_all(self, activate_s0=False):
+    async def activate_all(self, activate_s0: bool = False) -> None:
         """Activate all status requests."""
-        await self.addr_conn.conn.segment_scan_completed
+        await self.addr_conn.conn.segment_scan_completed_event.wait()
         for item in (
             list(lcn_defs.OutputPort)
             + list(lcn_defs.RelayPort)
@@ -502,13 +547,17 @@ class StatusRequestsHandler:
             + list(lcn_defs.Key)
             + list(lcn_defs.Var)
         ):
-            if item == lcn_defs.Var.UNKNOWN:
+            if isinstance(item, lcn_defs.Var) and item == lcn_defs.Var.UNKNOWN:
                 continue
-            if (not activate_s0) and (item in lcn_defs.Var.s0s):
+            if (
+                (not activate_s0)
+                and isinstance(item, lcn_defs.Var)
+                and (item in lcn_defs.Var.s0s)  # type: ignore
+            ):
                 continue
             await self.activate(item)
 
-    async def cancel_all(self):
+    async def cancel_all(self) -> None:
         """Cancel all status requests."""
         for item in (
             list(lcn_defs.OutputPort)
@@ -518,7 +567,7 @@ class StatusRequestsHandler:
             + list(lcn_defs.Key)
             + list(lcn_defs.Var)
         ):
-            if item == lcn_defs.Var.UNKNOWN:
+            if isinstance(item, lcn_defs.Var) and item == lcn_defs.Var.UNKNOWN:
                 continue
             await self.cancel(item)
 
@@ -529,24 +578,30 @@ class AbstractConnection(LcnAddr):
     Sends status requests to the connection and handles status responses.
     """
 
-    def __init__(self, conn, seg_id, addr_id, is_group, sw_age=None):
+    def __init__(
+        self,
+        conn: "PchkConnectionManager",
+        seg_id: int,
+        addr_id: int,
+        is_group: bool,
+        sw_age: Optional[int] = None,
+    ):
         """Construct AbstractConnection instance."""
         self.conn = conn
         super().__init__(seg_id=seg_id, addr_id=addr_id, is_group=is_group)
 
-        if sw_age is not None:
-            self._sw_age = sw_age
-        self._serial = None
-        self._manu = None
-        self._hw_type = None
+        self._sw_age: Optional[int] = sw_age
+        self._serial: Optional[int] = None
+        self._manu: Optional[int] = None
+        self._hw_type: Optional[int] = None
 
-        self.input_callbacks = []
+        self.input_callbacks: List[Callable[[inputs.Input], None]] = []
 
-    def get_sw_age(self):
+    def get_sw_age(self) -> Optional[int]:
         """Return standard sw_age."""
         return self._sw_age
 
-    def send_command(self, wants_ack, pck):
+    def send_command(self, wants_ack: bool, pck: str) -> None:
         """Send a command to the module represented by this class.
 
         :param    bool    wants_ack:    Also send a request for acknowledge.
@@ -563,7 +618,7 @@ class AbstractConnection(LcnAddr):
     # ## Methods for handling input objects
     # ##
 
-    async def async_process_input(self, inp):
+    async def async_process_input(self, inp: inputs.Input) -> None:
         """Is called by input object's process method.
 
         Method to handle incoming commands for this specific module (status,
@@ -572,7 +627,9 @@ class AbstractConnection(LcnAddr):
         for input_callback in self.input_callbacks:
             input_callback(inp)
 
-    def register_for_inputs(self, callback):
+    def register_for_inputs(
+        self, callback: Callable[[inputs.Input], None]
+    ) -> Callable[..., None]:
         """Register a function for callback on PCK message received.
 
         Returns a function to unregister the callback.
@@ -584,21 +641,21 @@ class AbstractConnection(LcnAddr):
     # ## Methods for sending PCK commands
     # ##
 
-    def dim_output(self, output_id, percent, ramp):
+    def dim_output(self, output_id: int, percent: float, ramp: int) -> None:
         """Send a dim command for a single output-port.
 
         :param    int    output_id:    Output id 0..3
-        :param    int    percent:      Brightness in percent 0..100
+        :param    float    percent:      Brightness in percent 0..100
         :param    int    ramp:         Ramp time in milliseconds
         """
         self.send_command(
             not self.is_group(), PckGenerator.dim_ouput(output_id, percent, ramp)
         )
 
-    def dim_all_outputs(self, percent, ramp, is1805=False):
+    def dim_all_outputs(self, percent: float, ramp: int, is1805: bool = False) -> None:
         """Send a dim command for all output-ports.
 
-        :param    int    percent:    Brightness in percent 0..100
+        :param    float    percent:    Brightness in percent 0..100
         :param    int    ramp:       Ramp time in milliseconds.
         :param    bool   is1805:     True if the target module's firmware is
                                      180501 or newer, otherwise False
@@ -607,18 +664,18 @@ class AbstractConnection(LcnAddr):
             not self.is_group(), PckGenerator.dim_all_outputs(percent, ramp, is1805)
         )
 
-    def rel_output(self, output_id, percent):
+    def rel_output(self, output_id: int, percent: float) -> None:
         """Send a command to change the value of an output-port.
 
         :param     int    output_id:    Output id 0..3
-        :param     int    percent:      Relative brightness in percent
+        :param     float    percent:      Relative brightness in percent
                                         -100..100
         """
         self.send_command(
             not self.is_group(), PckGenerator.rel_output(output_id, percent)
         )
 
-    def toggle_output(self, output_id, ramp):
+    def toggle_output(self, output_id: int, ramp: int) -> None:
         """Send a command that toggles a single output-port.
 
         Toggle mode: (on->off, off->on).
@@ -630,7 +687,7 @@ class AbstractConnection(LcnAddr):
             not self.is_group(), PckGenerator.toggle_output(output_id, ramp)
         )
 
-    def toggle_all_outputs(self, ramp):
+    def toggle_all_outputs(self, ramp: int) -> None:
         """Generate a command that toggles all output-ports.
 
         Toggle Mode:  (on->off, off->on).
@@ -639,7 +696,7 @@ class AbstractConnection(LcnAddr):
         """
         self.send_command(not self.is_group(), PckGenerator.toggle_all_outputs(ramp))
 
-    def control_relays(self, states):
+    def control_relays(self, states: List[lcn_defs.RelayStateModifier]) -> None:
         """Send a command to control relays.
 
         :param    states:   The 8 modifiers for the relay states as alist
@@ -647,7 +704,7 @@ class AbstractConnection(LcnAddr):
         """
         self.send_command(not self.is_group(), PckGenerator.control_relays(states))
 
-    def control_motors_relays(self, states):
+    def control_motors_relays(self, states: List[lcn_defs.MotorStateModifier]) -> None:
         """Send a command to control motors via relays.
 
         :param    states:   The 4 modifiers for the cover states as a list
@@ -657,7 +714,11 @@ class AbstractConnection(LcnAddr):
             not self.is_group(), PckGenerator.control_motors_relays(states)
         )
 
-    def control_motors_outputs(self, state, reverse_time=None):
+    def control_motors_outputs(
+        self,
+        state: lcn_defs.MotorStateModifier,
+        reverse_time: Optional[lcn_defs.MotorReverseTime] = None,
+    ) -> None:
         """Send a command to control a motor via output ports 1+2.
 
         :param    MotorStateModifier  state: The modifier for the cover state
@@ -671,8 +732,13 @@ class AbstractConnection(LcnAddr):
         )
 
     def activate_scene(
-        self, register_id, scene_id, output_ports=(), relay_ports=(), ramp=None
-    ):
+        self,
+        register_id: int,
+        scene_id: int,
+        output_ports: Sequence[lcn_defs.OutputPort] = (),
+        relay_ports: Sequence[lcn_defs.RelayPort] = (),
+        ramp: Optional[int] = None,
+    ) -> None:
         """Activate the stored states for the given scene.
 
         :param    int                register_id:    Register id 0..9
@@ -697,18 +763,31 @@ class AbstractConnection(LcnAddr):
                 PckGenerator.activate_scene_relay(scene_id, relay_ports),
             )
 
-    def var_abs(self, var, value, unit=lcn_defs.VarUnit.NATIVE, is2013=None):
+    def var_abs(
+        self,
+        var: lcn_defs.Var,
+        value_or_float: Union[float, lcn_defs.VarValue],
+        unit: lcn_defs.VarUnit = lcn_defs.VarUnit.NATIVE,
+        is2013: Optional[bool] = None,
+    ) -> None:
         """Send a command to set the absolute value to a variable.
 
         :param     Var        var:      Variable
         :param     float      value:    Absolute value to set
         :param     VarUnit    unit:     Unit of variable
         """
-        if value is not None and not isinstance(value, lcn_defs.VarValue):
-            value = lcn_defs.VarValue.from_var_unit(value, unit, True)
+        if isinstance(value_or_float, lcn_defs.VarValue):
+            value = value_or_float
+        else:
+            value = lcn_defs.VarValue.from_var_unit(value_or_float, unit, True)
 
-        if is2013 is None:
-            is2013 = self.get_sw_age() >= 0x170206
+        if is2013 is not None:
+            sw_is2013 = is2013
+        elif self._sw_age is not None:
+            sw_is2013 = self._sw_age >= 0x170206
+        else:
+            sw_is2013 = False
+
         if lcn_defs.Var.to_var_id(var) != -1:
             # Absolute commands for variables 1-12 are not supported
             if self.get_id() == 4 and self.is_group():
@@ -721,12 +800,12 @@ class AbstractConnection(LcnAddr):
                 # We fake the missing command by using reset and relative
                 # commands.
                 self.send_command(
-                    not self.is_group(), PckGenerator.var_reset(var, is2013)
+                    not self.is_group(), PckGenerator.var_reset(var, sw_is2013)
                 )
                 self.send_command(
                     not self.is_group(),
                     PckGenerator.var_rel(
-                        var, lcn_defs.RelVarRef.CURRENT, value.to_native(), is2013
+                        var, lcn_defs.RelVarRef.CURRENT, value.to_native(), sw_is2013
                     ),
                 )
         else:
@@ -734,24 +813,28 @@ class AbstractConnection(LcnAddr):
                 not self.is_group(), PckGenerator.var_abs(var, value.to_native())
             )
 
-    def var_reset(self, var, is2013=None):
+    def var_reset(self, var: lcn_defs.Var, is2013: Optional[bool] = None) -> None:
         """Send a command to reset the variable value.
 
         :param    Var    var:    Variable
         """
-        if is2013 is None:
-            is2013 = self.get_sw_age() >= 0x170206
+        if is2013 is not None:
+            sw_is2013 = is2013
+        elif self._sw_age is not None:
+            sw_is2013 = self._sw_age >= 0x170206
+        else:
+            sw_is2013 = False
 
-        self.send_command(not self.is_group(), PckGenerator.var_reset(var, is2013))
+        self.send_command(not self.is_group(), PckGenerator.var_reset(var, sw_is2013))
 
     def var_rel(
         self,
-        var,
-        value,
-        unit=lcn_defs.VarUnit.NATIVE,
-        value_ref=lcn_defs.RelVarRef.CURRENT,
-        is2013=None,
-    ):
+        var: lcn_defs.Var,
+        value_or_float: Union[float, lcn_defs.VarValue],
+        unit: lcn_defs.VarUnit = lcn_defs.VarUnit.NATIVE,
+        value_ref: lcn_defs.RelVarRef = lcn_defs.RelVarRef.CURRENT,
+        is2013: Optional[bool] = None,
+    ) -> None:
         """Send a command to change the value of a variable.
 
         :param     Var        var:      Variable
@@ -759,17 +842,24 @@ class AbstractConnection(LcnAddr):
                                         negative)
         :param     VarUnit    unit:     Unit of variable
         """
-        if value is not None and not isinstance(value, lcn_defs.VarValue):
-            value = lcn_defs.VarValue.from_var_unit(value, unit, True)
+        if isinstance(value_or_float, lcn_defs.VarValue):
+            value = value_or_float
+        else:
+            value = lcn_defs.VarValue.from_var_unit(value_or_float, unit, True)
 
-        if is2013 is None:
-            is2013 = self.get_sw_age() >= 0x170206
+        if is2013 is not None:
+            sw_is2013 = is2013
+        elif self._sw_age is not None:
+            sw_is2013 = self._sw_age >= 0x170206
+        else:
+            sw_is2013 = False
+
         self.send_command(
             not self.is_group(),
-            PckGenerator.var_rel(var, value_ref, value.to_native(), is2013),
+            PckGenerator.var_rel(var, value_ref, value.to_native(), sw_is2013),
         )
 
-    def lock_regulator(self, reg_id, state):
+    def lock_regulator(self, reg_id: int, state: bool) -> None:
         """Send a command to lock a regulator.
 
         :param    int        reg_id:        Regulator id
@@ -781,7 +871,7 @@ class AbstractConnection(LcnAddr):
                 not self.is_group(), PckGenerator.lock_regulator(reg_id, state)
             )
 
-    def control_led(self, led, state):
+    def control_led(self, led: lcn_defs.LedPort, state: lcn_defs.LedStatus) -> None:
         """Send a command to control a led.
 
         :param    LedPort      led:        Led port
@@ -791,7 +881,7 @@ class AbstractConnection(LcnAddr):
             not self.is_group(), PckGenerator.control_led(led.value, state)
         )
 
-    def send_keys(self, keys, cmd):
+    def send_keys(self, keys: List[List[bool]], cmd: lcn_defs.SendKeyCommand) -> None:
         """Send a command to send keys.
 
         :param    list(bool)[4][8]    keys:    2d-list with [table_id][key_id]
@@ -807,7 +897,9 @@ class AbstractConnection(LcnAddr):
                     not self.is_group(), PckGenerator.send_keys(cmds, key_states)
                 )
 
-    def send_keys_hit_deferred(self, keys, delay_time, delay_unit):
+    def send_keys_hit_deferred(
+        self, keys: List[List[bool]], delay_time: int, delay_unit: lcn_defs.TimeUnit
+    ) -> None:
         """Send a command to send keys deferred.
 
         :param    list(bool)[4][8]    keys:          2d-list with
@@ -826,7 +918,9 @@ class AbstractConnection(LcnAddr):
                     ),
                 )
 
-    def lock_keys(self, table_id, states):
+    def lock_keys(
+        self, table_id: int, states: List[lcn_defs.KeyLockStateModifier]
+    ) -> None:
         """Send a command to lock keys.
 
         :param    int                     table_id:  Table id: 0..3
@@ -835,7 +929,9 @@ class AbstractConnection(LcnAddr):
         """
         self.send_command(not self.is_group(), PckGenerator.lock_keys(table_id, states))
 
-    def lock_keys_tab_a_temporary(self, delay_time, delay_unit, states):
+    def lock_keys_tab_a_temporary(
+        self, delay_time: int, delay_unit: lcn_defs.TimeUnit, states: List[bool]
+    ) -> None:
         """Send a command to lock keys in table A temporary.
 
         :param    int        delay_time:    Time to lock keys
@@ -848,7 +944,7 @@ class AbstractConnection(LcnAddr):
             PckGenerator.lock_keys_tab_a_temporary(delay_time, delay_unit, states),
         )
 
-    def dyn_text(self, row_id, text):
+    def dyn_text(self, row_id: int, text: str) -> None:
         """Send dynamic text to a module.
 
         :param    int    row_id:    Row id 0..3
@@ -864,7 +960,7 @@ class AbstractConnection(LcnAddr):
                     PckGenerator.dyn_text_part(row_id, part_id, part),
                 )
 
-    def pck(self, pck):
+    def pck(self, pck: str) -> None:
         """Send arbitrary PCK command.
 
         :param    str    pck:    PCK command
@@ -878,11 +974,23 @@ class GroupConnection(AbstractConnection):
     It is assumed that all modules within this group are newer than FW170206
     """
 
-    def __init__(self, conn, seg_id, grp_id, sw_age=0x170206):
+    def __init__(
+        self,
+        conn: "PchkConnectionManager",
+        seg_id: int,
+        grp_id: int,
+        sw_age: int = 0x170206,
+    ):
         """Construct GroupConnection instance."""
         super().__init__(conn, seg_id, grp_id, True, sw_age=sw_age)
 
-    def var_abs(self, var, value, unit=lcn_defs.VarUnit.NATIVE, is2013=None):
+    def var_abs(
+        self,
+        var: lcn_defs.Var,
+        value: Union[float, lcn_defs.VarValue],
+        unit: lcn_defs.VarUnit = lcn_defs.VarUnit.NATIVE,
+        is2013: Optional[bool] = None,
+    ) -> None:
         """Send a command to set the absolute value to a variable.
 
         :param     Var        var:      Variable
@@ -902,7 +1010,7 @@ class GroupConnection(AbstractConnection):
         ]:
             super().var_abs(var, value, unit, is2013=False)
 
-    def var_reset(self, var, is2013=None):
+    def var_reset(self, var: lcn_defs.Var, is2013: Optional[bool] = None) -> None:
         """Send a command to reset the variable value.
 
         :param    Var    var:    Variable
@@ -919,12 +1027,12 @@ class GroupConnection(AbstractConnection):
 
     def var_rel(
         self,
-        var,
-        value,
-        unit=lcn_defs.VarUnit.NATIVE,
-        value_ref=lcn_defs.RelVarRef.CURRENT,
-        is2013=None,
-    ):
+        var: lcn_defs.Var,
+        value: Union[float, lcn_defs.VarValue],
+        unit: lcn_defs.VarUnit = lcn_defs.VarUnit.NATIVE,
+        value_ref: lcn_defs.RelVarRef = lcn_defs.RelVarRef.CURRENT,
+        is2013: Optional[bool] = None,
+    ) -> None:
         """Send a command to change the value of a variable.
 
         :param     Var        var:      Variable
@@ -947,11 +1055,11 @@ class GroupConnection(AbstractConnection):
         ]:
             super().var_rel(var, value, is2013=False)
 
-    async def activate_status_request_handler(self, item):
+    async def activate_status_request_handler(self, item: Any) -> None:
         """Activate a specific TimeoutRetryHandler for status requests."""
         await self.conn.segment_scan_completed_event.wait()
 
-    async def activate_status_request_handlers(self):
+    async def activate_status_request_handlers(self) -> None:
         """Activate all TimeoutRetryHandlers for status requests."""
         # self.request_serial.activate()
         await self.conn.segment_scan_completed_event.wait()
@@ -962,12 +1070,12 @@ class ModuleConnection(AbstractConnection):
 
     def __init__(
         self,
-        conn,
-        seg_id,
-        mod_id,
-        activate_status_requests=False,
-        has_s0_enabled=False,
-        sw_age=None,
+        conn: "PchkConnectionManager",
+        seg_id: int,
+        mod_id: int,
+        activate_status_requests: bool = False,
+        has_s0_enabled: bool = False,
+        sw_age: Optional[int] = None,
     ):
         """Construct ModuleConnection instance."""
         super().__init__(conn, seg_id, mod_id, False, sw_age=sw_age)
@@ -976,7 +1084,7 @@ class ModuleConnection(AbstractConnection):
         # List of queued PCK commands to be acknowledged by the LCN module.
         # Commands are always without address header.
         # Note that the first one might currently be "in progress".
-        self.pck_commands_with_ack = deque()
+        self.pck_commands_with_ack: Deque[str] = deque()
 
         self.request_curr_pck_command_with_ack = TimeoutRetryHandler(
             conn.settings["NUM_TRIES"], conn.settings["DEFAULT_TIMEOUT_MSEC"]
@@ -994,7 +1102,7 @@ class ModuleConnection(AbstractConnection):
         if activate_status_requests:
             asyncio.create_task(self.activate_status_request_handlers())
 
-    def send_command(self, wants_ack, pck):
+    def send_command(self, wants_ack: bool, pck: str) -> None:
         """Send a command to the module represented by this class.
 
         :param    bool    wants_ack:    Also send a request for acknowledge.
@@ -1005,38 +1113,38 @@ class ModuleConnection(AbstractConnection):
         else:
             super().send_command(False, pck)
 
-    async def activate_properties_request_handlers(self):
+    async def activate_properties_request_handlers(self) -> None:
         """Activate all TimeoutRetryHandlers for property requests."""
         await self.properties_requests.activate_all()
 
-    async def activate_status_request_handler(self, item):
+    async def activate_status_request_handler(self, item: Any) -> None:
         """Activate a specific TimeoutRetryHandler for status requests."""
         await self.status_requests.activate(item)
 
-    async def activate_status_request_handlers(self):
+    async def activate_status_request_handlers(self) -> None:
         """Activate all TimeoutRetryHandlers for status requests."""
         await self.status_requests.activate_all(activate_s0=self.has_s0_enabled)
 
-    async def cancel_properties_request_handlers(self):
+    async def cancel_properties_request_handlers(self) -> None:
         """Canecl all TimeoutRetryHandlers for status requests."""
         await self.properties_requests.cancel_all()
 
-    async def cancel_status_request_handler(self, item):
+    async def cancel_status_request_handler(self, item: Any) -> None:
         """Cancel a specific TimeoutRetryHandler for status requests."""
         await self.status_requests.cancel(item)
 
-    async def cancel_status_request_handlers(self):
+    async def cancel_status_request_handlers(self) -> None:
         """Canecl all TimeoutRetryHandlers for status requests."""
         await self.status_requests.cancel_all()
 
-    async def cancel_requests(self):
+    async def cancel_requests(self) -> None:
         """Cancel all TimeoutRetryHandlers."""
         await self.status_requests.cancel_all()
         await self.properties_requests.cancel_all()
         await self.request_curr_pck_command_with_ack.cancel()
         self.pck_commands_with_ack.clear()
 
-    def set_s0_enabled(self, s0_enabled):
+    def set_s0_enabled(self, s0_enabled: bool) -> None:
         """Set the activation status for S0 variables.
 
         :param     bool    s0_enabled:   If True, a BU4L has to be connected
@@ -1044,11 +1152,11 @@ class ModuleConnection(AbstractConnection):
         """
         self.has_s0_enabled = s0_enabled
 
-    def get_s0_enabled(self):
+    def get_s0_enabled(self) -> bool:
         """Get the activation status for S0 variables."""
         return self.has_s0_enabled
 
-    def get_sw_age(self):
+    def get_sw_age(self) -> int:
         """Get the LCN module's firmware date."""
         return self.properties_requests.serials.software_serial
 
@@ -1056,7 +1164,7 @@ class ModuleConnection(AbstractConnection):
     # ## Retry logic if an acknowledge is requested
     # ##
 
-    def schedule_command_with_ack(self, pck):
+    def schedule_command_with_ack(self, pck: str) -> None:
         """Schedule the next command which requests an acknowledge."""
         # add pck command to pck commands list
         self.pck_commands_with_ack.append(pck)
@@ -1064,7 +1172,9 @@ class ModuleConnection(AbstractConnection):
         # Will do nothing if another one is still in progress.
         self.try_process_next_command_with_ack()
 
-    async def on_ack(self, code=-1, timeout_msec=DEFAULT_TIMEOUT_MSEC):
+    async def on_ack(
+        self, code: int = -1, timeout_msec: int = DEFAULT_TIMEOUT_MSEC
+    ) -> None:
         """Is called whenever an acknowledge is received from the LCN module.
 
         :param     int    code:           The LCN internal code. -1 means
@@ -1080,14 +1190,14 @@ class ModuleConnection(AbstractConnection):
             # Try to process next acknowledged command
             self.try_process_next_command_with_ack()
 
-    def try_process_next_command_with_ack(self):
+    def try_process_next_command_with_ack(self) -> None:
         """Send the next acknowledged command from the queue."""
         if self.pck_commands_with_ack and (
             not self.request_curr_pck_command_with_ack.is_active()
         ):
             self.request_curr_pck_command_with_ack.activate()
 
-    def request_curr_pck_command_with_ack_timeout(self, failed):
+    def request_curr_pck_command_with_ack_timeout(self, failed: bool) -> None:
         """I called on command with acknowledge timeout."""
         # Use the chance to remove a failed command first
         if failed:
@@ -1100,7 +1210,7 @@ class ModuleConnection(AbstractConnection):
                 + pck
             )
 
-    async def async_process_input(self, inp):
+    async def async_process_input(self, inp: inputs.Input) -> None:
         """Is called by input object's process method.
 
         Method to handle incoming commands for this specific module (status,
@@ -1108,7 +1218,8 @@ class ModuleConnection(AbstractConnection):
         """
         if isinstance(inp, inputs.ModAck):
             asyncio.create_task(self.on_ack(inp.code, DEFAULT_TIMEOUT_MSEC))
-            return
+            return None
+
         # handle typeless variable responses
         if isinstance(inp, inputs.ModStatusVar):
             inp = self.status_requests.preprocess_modstatusvar(inp)
@@ -1122,60 +1233,60 @@ class ModuleConnection(AbstractConnection):
     # ## properties
 
     @property
-    def hardware_serial(self):
+    def hardware_serial(self) -> int:
         """Return hardware serial of module."""
         return self.properties_requests.serials.hardware_serial
 
     @property
-    def manu(self):
+    def manu(self) -> int:
         """Return manufacturing of module."""
         return self.properties_requests.serials.manu
 
     @property
-    def software_serial(self):
+    def software_serial(self) -> int:
         """Return software serial of module."""
         return self.properties_requests.serials.software_serial
 
     @property
-    def hw_type(self):
+    def hw_type(self) -> int:
         """Return hardware type of module."""
         return self.properties_requests.serials.hardware_type
 
     @property
-    def serial(self):
+    def serial(self) -> Tuple[int, int, int, int]:
         """Return serials number information."""
         return (self.hardware_serial, self.manu, self.software_serial, self.hw_type)
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Retrun stored name."""
         return self.properties_requests.name_comment.name
 
     @property
-    def comment(self):
+    def comment(self) -> str:
         """Return stored comments."""
         return self.properties_requests.name_comment.comment
 
     @property
-    def oem_text(self):
+    def oem_text(self) -> List[str]:
         """Return stored OEM text."""
         return self.properties_requests.name_comment.oem_text
 
     # ## future properties
 
     @property
-    def serial_known(self):
+    def serial_known(self) -> Awaitable[bool]:
         """Check if serials have already been received from module."""
         return self.properties_requests.serials.serial_known.wait()
 
-    async def request_name(self):
+    async def request_name(self) -> str:
         """Request module name."""
         return await self.properties_requests.name_comment.request_name()
 
-    async def request_comment(self):
+    async def request_comment(self) -> str:
         """Request comments from a module."""
         return await self.properties_requests.name_comment.request_comment()
 
-    async def request_oem_text(self):
+    async def request_oem_text(self) -> List[str]:
         """Request OEM text from a module."""
         return await self.properties_requests.name_comment.request_oem_text()

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ commands =
 deps =
     mypy
 commands =
-    mypy {posargs:pypck}
+    mypy {posargs:--strict pypck}
 
 
 [pytest]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, lint, pylint, mypy, cov
+envlist = py37, py38, format, lint, pylint, mypy, cov
 skip_missing_interpreters = True
 
 [testenv]
@@ -32,6 +32,12 @@ deps =
 commands =
     flake8 {posargs:pypck}
     pydocstyle {posargs:pypck}
+
+[testenv:format]
+deps =
+    black
+commands =
+    black {posargs:--check pypck tests}
 
 [testenv:mypy]
 deps =


### PR DESCRIPTION
Issue #10 

Add type annotations to the module and connection parts of pypck. Now mypy can be configured to be strict. Also add a format stage to tox warning on improperly formatted code.