### PR TITLE
Feature/commands beep leer store scene

### DIFF
--- a/pypck/connection.py
+++ b/pypck/connection.py
@@ -469,7 +469,12 @@ class PchkConnectionManager(PchkConnection):
             for segment_id in segment_coupler_ids:
                 if segment_id == self.local_seg_id:
                     segment_id = 0
-                await self.async_send_command(">G{:03d}003!LEER".format(segment_id))
+                await self.async_send_command(
+                    PckGenerator.generate_address_header(
+                        LcnAddr(segment_id, 3, True), self.local_seg_id, True
+                    )
+                    + PckGenerator.empty()
+                )
 
             # Wait loop which is extended on every serial number received
             while True:

--- a/pypck/lcn_defs.py
+++ b/pypck/lcn_defs.py
@@ -1222,6 +1222,13 @@ class KeyLockStateModifier(Enum):
     NOCHANGE = "-"
 
 
+class BeepSound(Enum):
+    """Beep sounds supported by LCN modules."""
+
+    NORMAL = "N"
+    SPECIAL = "S"
+
+
 default_connection_settings: Dict[str, Any] = {
     "NUM_TRIES": 3,  # Total number of request to sent before going into
     # failed-state.

--- a/pypck/module.py
+++ b/pypck/module.py
@@ -957,6 +957,14 @@ class AbstractConnection(LcnAddr):
                     PckGenerator.dyn_text_part(row_id, part_id, part),
                 )
 
+    def beep(self, sound: lcn_defs.BeepSound, count: int) -> None:
+        """Send a command to make count number of beep sounds.
+
+        :param    BeepSound sound:  Beep sound style
+        :param    int       count:  Number of beeps (1..15)
+        """
+        self.send_command(not self.is_group(), PckGenerator.beep(sound, count))
+
     def pck(self, pck: str) -> None:
         """Send arbitrary PCK command.
 

--- a/pypck/module.py
+++ b/pypck/module.py
@@ -760,6 +760,38 @@ class AbstractConnection(LcnAddr):
                 PckGenerator.activate_scene_relay(scene_id, relay_ports),
             )
 
+    def store_scene(
+        self,
+        register_id: int,
+        scene_id: int,
+        output_ports: Sequence[lcn_defs.OutputPort] = (),
+        relay_ports: Sequence[lcn_defs.RelayPort] = (),
+        ramp: Optional[int] = None,
+    ) -> None:
+        """Store states in the given scene.
+
+        :param    int                register_id:    Register id 0..9
+        :param    int                scene_id:       Scene id 0..9
+        :param    list(OutputPort)   output_ports:   Output ports to store
+                                                     as list
+        :param    list(RelayPort)    relay_ports:    Relay ports to store
+                                                     as list
+        :param    int                ramp:           Ramp value
+        """
+        self.send_command(
+            not self.is_group(), PckGenerator.change_scene_register(register_id)
+        )
+        if output_ports:
+            self.send_command(
+                not self.is_group(),
+                PckGenerator.store_scene_output(scene_id, output_ports, ramp),
+            )
+        if relay_ports:
+            self.send_command(
+                not self.is_group(),
+                PckGenerator.store_scene_relay(scene_id, relay_ports),
+            )
+
     def var_abs(
         self,
         var: lcn_defs.Var,

--- a/pypck/module.py
+++ b/pypck/module.py
@@ -965,6 +965,10 @@ class AbstractConnection(LcnAddr):
         """
         self.send_command(not self.is_group(), PckGenerator.beep(sound, count))
 
+    def ping(self) -> None:
+        """Send a command that does nothing and request an acknowledgement."""
+        self.send_command(True, PckGenerator.empty())
+
     def pck(self, pck: str) -> None:
         """Send arbitrary PCK command.
 

--- a/pypck/pck_commands.py
+++ b/pypck/pck_commands.py
@@ -999,3 +999,16 @@ class PckGenerator:
         for port in relay_ports:
             relays_mask[port.value] = "1"
         return "SZA0{:03d}{:s}".format(scene_id, "".join(relays_mask))
+
+    @staticmethod
+    def beep(sound: lcn_defs.BeepSound, count: int) -> str:
+        """Make count number of beep sounds.
+
+        :param    BeepSound sound:  Beep sound style
+        :param    int       count:  Number of beeps (1..15)
+        :return:  The PCK command (without address header) as text
+        :rtype:   str
+        """
+        if (count < 1) or (count > 15):
+            raise ValueError("Wrong number of beeps.")
+        return "PI{:s}{:02d}".format(sound, count)

--- a/pypck/pck_commands.py
+++ b/pypck/pck_commands.py
@@ -1012,3 +1012,15 @@ class PckGenerator:
         if (count < 1) or (count > 15):
             raise ValueError("Wrong number of beeps.")
         return "PI{:s}{:02d}".format(sound, count)
+
+    @staticmethod
+    def empty() -> str:
+        """Generate an empty command (LEER) that does nothing.
+
+        Combine with request for acknowledgement to discover and
+        ping modules and to discover and verify group memberships.
+
+        :return:  The PCK command (without address header) as text
+        :rtype:   str
+        """
+        return "LEER"


### PR DESCRIPTION
Issues #15 #22 

Add further commands to `PckGenerator`:
* `beep` makes a module beep up to 15 times
* `do_nothing` does nothing and can used to discover and ping modules
* `store_scene_*` commands can store the current state of outputs and relays in scene-registers

@alengwenus Please review.  As far as I understand the random and  incomplete pieces of information that I could find, the scene commands for activation and store are identical except for the action flags `"S"` and `"A"`. Similarly for the beep command. 