### PR TITLE
Add HardwareType Enum

### DIFF
--- a/pypck/inputs.py
+++ b/pypck/inputs.py
@@ -351,7 +351,7 @@ class ModSn(ModInput):
         serial: int,
         manu: int,
         sw_age: int,
-        hw_type: int,
+        hw_type: lcn_defs.HardwareType,
     ):
         """Construct ModInput object."""
         super().__init__(physical_source_addr)
@@ -378,7 +378,7 @@ class ModSn(ModInput):
             serial = int(matcher.group("sn"), 16)
             manu = int(matcher.group("manu"), 16)
             sw_age = int(matcher.group("sw_age"), 16)
-            hw_type = int(matcher.group("hw_type"))
+            hw_type = lcn_defs.HardwareType(int(matcher.group("hw_type")))
             return [ModSn(addr, serial, manu, sw_age, hw_type)]
 
         return None

--- a/pypck/lcn_defs.py
+++ b/pypck/lcn_defs.py
@@ -13,7 +13,7 @@ Contributors:
 import math
 import re
 from enum import Enum, auto
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Dict, Tuple, Union, no_type_check
 
 LCN_ENCODING = "utf-8"
 PATTERN_SPLIT_PORT_PIN = re.compile(r"(?P<port>[a-zA-Z]+)(?P<pin>\d+)")
@@ -1225,73 +1225,93 @@ class BeepSound(Enum):
     SPECIAL = "S"
 
 
+HARDWARE_NAMES = dict(
+    [
+        (-1, "UnknownModuleType"),
+        (1, "LCN-SW1.0"),
+        (2, "LCN-SW1.1"),
+        (3, "LCN-UP1.0"),
+        (4, "LCN-UP2"),
+        (5, "LCN-SW2"),
+        (6, "LCN-UP-Profi1-Plus"),
+        (7, "LCN-DI12"),
+        (8, "LCN-HU"),
+        (9, "LCN-SH"),
+        (10, "LCN-UP2"),
+        (11, "LCN-UPP"),
+        (12, "LCN-SK"),
+        (14, "LCN-LD"),
+        (15, "LCN-SH-Plus"),
+        (17, "LCN-UPS"),
+        (18, "LCN_UPS24V"),
+        (19, "LCN-GTM"),
+        (20, "LCN-SHS"),
+        (21, "LCN-ESD"),
+        (22, "LCN-EB2"),
+        (23, "LCN-MRS"),
+        (24, "LCN-EB11"),
+        (25, "LCN-UMR"),
+        (26, "LCN-UPU"),
+        (27, "LCN-UMR24V"),
+        (28, "LCN-SHD"),
+        (29, "LCN-SHU"),
+        (30, "LCN-SR6"),
+    ]
+)
+
+
 class HardwareType(Enum):
     """Hardware types as returned by serial number request."""
 
-    UNKNOWN = (-1, "UnknownModuleType")
-    SW1_0 = (1, "LCN-SW1.0")
-    SW1_1 = (2, "LCN-SW1.1")
-    UP1_0 = (3, "LCN-UP1.0")
-    UP2 = (4, "LCN-UP2")
-    SW2 = (5, "LCN-SW2")
-    UP_PROFI1_PLUS = (6, "LCN-UP-Profi1-Plus")
-    DI12 = (7, "LCN-DI12")
-    HU = (8, "LCN-HU")
-    SH = (9, "LCN-SH")
-    UPP = (11, "LCN-UPP")
-    SK = (12, "LCN-SK")
-    LD = (14, "LCN-LD")
-    SH_PLUS = (15, "LCN-SH-Plus")
-    UPS = (17, "LCN-UPS")
-    UPS24V = (18, "LCN_UPS24V")
-    GTM = (19, "LCN-GTM")
-    SHS = (20, "LCN-SHS")
-    ESD = (21, "LCN-ESD")
-    EB2 = (22, "LCN-EB2")
-    MRS = (23, "LCN-MRS")
-    EB11 = (24, "LCN-EB11")
-    UMR = (25, "LCN-UMR")
-    UPU = (26, "LCN-UPU")
-    UMR24V = (27, "LCN-UMR24V")
-    SHD = (28, "LCN-SHD")
-    SHU = (29, "LCN-SHU")
-    SR6 = (30, "LCN-SR6")
+    UNKNOWN = -1
+    SW1_0 = 1
+    SW1_1 = 2
+    UP1_0 = 3
+    UP2 = 4
+    SW2 = 5
+    UP_PROFI1_PLUS = 6
+    DI12 = 7
+    HU = 8
+    SH = 9
+    UPP = 11
+    SK = 12
+    LD = 14
+    SH_PLUS = 15
+    UPS = 17
+    UPS24V = 18
+    GTM = 19
+    SHS = 20
+    ESD = 21
+    EB2 = 22
+    MRS = 23
+    EB11 = 24
+    UMR = 25
+    UPU = 26
+    UMR24V = 27
+    SHD = 28
+    SHU = 29
+    SR6 = 30
 
     @property
-    def hw_id(self) -> int:
+    def hw_id(self) -> Any:
         """Get the LCN hardware id."""
-        return self._hw_id
+        return self.value
 
     @property
     def hw_name(self) -> str:
         """Get the LCN hardware name."""
-        return self._hw_name
-
-    @staticmethod
-    def _new(clss: "HardwareType", hw_id: int) -> "HardwareType":
-        """Override HardwareType creation.
-
-        Is used to replace __new__() method after class definition.
-        """
-        for hw_type in HardwareType:
-            if hw_type.value[0] == hw_id:
-                break
-        else:
-            if hw_id == 10:
-                hw_type = HardwareType.UP2
-            else:
-                raise ValueError(
-                    "%r is not a valid %s" % (hw_id, clss.__name__)  # type: ignore
-                )
-        return hw_type
-
-    def __init__(self, hw_id: int, hw_name: str) -> None:
-        """Construct HardwareType."""
-        self._hw_id = hw_id
-        self._hw_name = hw_name
+        return HARDWARE_NAMES[self.value]
 
 
-setattr(HardwareType, "__new__", HardwareType._new)  # pylint: disable=protected-access
+@no_type_check
+def hw_type_new(cls, value):
+    """Replace Hardwaretype.__new__."""
+    if value == 10:
+        value = 4
+    return super(HardwareType, cls).__new__(cls, value)
+
+
+setattr(HardwareType, "__new__", hw_type_new)
 
 
 default_connection_settings: Dict[str, Any] = {

--- a/pypck/lcn_defs.py
+++ b/pypck/lcn_defs.py
@@ -673,7 +673,7 @@ class VarValue:
     :param    int    native_value:    The native value
     """
 
-    def __init__(self, native_value: int):
+    def __init__(self, native_value: int) -> None:
         """Construct with native LCN value."""
         self.native_value = native_value
 
@@ -1223,6 +1223,75 @@ class BeepSound(Enum):
 
     NORMAL = "N"
     SPECIAL = "S"
+
+
+class HardwareType(Enum):
+    """Hardware types as returned by serial number request."""
+
+    UNKNOWN = (-1, "UnknownModuleType")
+    SW1_0 = (1, "LCN-SW1.0")
+    SW1_1 = (2, "LCN-SW1.1")
+    UP1_0 = (3, "LCN-UP1.0")
+    UP2 = (4, "LCN-UP2")
+    SW2 = (5, "LCN-SW2")
+    UP_PROFI1_PLUS = (6, "LCN-UP-Profi1-Plus")
+    DI12 = (7, "LCN-DI12")
+    HU = (8, "LCN-HU")
+    SH = (9, "LCN-SH")
+    UPP = (11, "LCN-UPP")
+    SK = (12, "LCN-SK")
+    LD = (14, "LCN-LD")
+    SH_PLUS = (15, "LCN-SH-Plus")
+    UPS = (17, "LCN-UPS")
+    UPS24V = (18, "LCN_UPS24V")
+    GTM = (19, "LCN-GTM")
+    SHS = (20, "LCN-SHS")
+    ESD = (21, "LCN-ESD")
+    EB2 = (22, "LCN-EB2")
+    MRS = (23, "LCN-MRS")
+    EB11 = (24, "LCN-EB11")
+    UMR = (25, "LCN-UMR")
+    UPU = (26, "LCN-UPU")
+    UMR24V = (27, "LCN-UMR24V")
+    SHD = (28, "LCN-SHD")
+    SHU = (29, "LCN-SHU")
+    SR6 = (30, "LCN-SR6")
+
+    @property
+    def hw_id(self) -> int:
+        """Get the LCN hardware id."""
+        return self._hw_id
+
+    @property
+    def hw_name(self) -> str:
+        """Get the LCN hardware name."""
+        return self._hw_name
+
+    @staticmethod
+    def _new(clss: "HardwareType", hw_id: int) -> "HardwareType":
+        """Override HardwareType creation.
+
+        Is used to replace __new__() method after class definition.
+        """
+        for hw_type in HardwareType:
+            if hw_type.value[0] == hw_id:
+                break
+        else:
+            if hw_id == 10:
+                hw_type = HardwareType.UP2
+            else:
+                raise ValueError(
+                    "%r is not a valid %s" % (hw_id, clss.__name__)  # type: ignore
+                )
+        return hw_type
+
+    def __init__(self, hw_id: int, hw_name: str) -> None:
+        """Construct HardwareType."""
+        self._hw_id = hw_id
+        self._hw_name = hw_name
+
+
+setattr(HardwareType, "__new__", HardwareType._new)  # pylint: disable=protected-access
 
 
 default_connection_settings: Dict[str, Any] = {

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -156,7 +156,7 @@ async def test_module_sn_response(pchk_server, pypck_client):
     assert module.hardware_serial == 0x1AB20A1234
     assert module.manu == 1
     assert module.software_serial == 0x190B11
-    assert module.hw_type == 15
+    assert module.hw_type.value == 15
 
 
 @pytest.mark.asyncio

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,25 +1,31 @@
 """Tests for input message parsing for bus messages"""
 
 import pytest
-
 from pypck.inputs import (
     InputParser,
     ModAck,
+    ModNameComment,
+    ModSendCommandHost,
     ModSk,
     ModSn,
-    ModNameComment,
+    ModStatusBinSensors,
+    ModStatusKeyLocks,
+    ModStatusLedsAndLogicOps,
     ModStatusOutput,
     ModStatusOutputNative,
     ModStatusRelays,
-    ModStatusBinSensors,
     ModStatusVar,
-    ModStatusLedsAndLogicOps,
-    ModStatusKeyLocks,
-    ModSendCommandHost,
 )
 from pypck.lcn_addr import LcnAddr
-from pypck.lcn_defs import OutputPort, Var, VarUnit, VarValue, LedStatus, LogicOpStatus
-
+from pypck.lcn_defs import (
+    HardwareType,
+    LedStatus,
+    LogicOpStatus,
+    OutputPort,
+    Var,
+    VarUnit,
+    VarValue,
+)
 
 MESSAGES = {
     # Ack
@@ -28,8 +34,20 @@ MESSAGES = {
     # SK
     "=M000010.SK007": (ModSk, 7),
     # SN
-    "=M000010.SN1AB20A123401FW190B11HW015": (ModSn, 0x1AB20A1234, 0x1, 0x190B11, 15),
-    "=M000010.SN1234567890AFFW190011HW255": (ModSn, 0x1234567890, 0xAF, 0x190011, 255),
+    "=M000010.SN1AB20A123401FW190B11HW015": (
+        ModSn,
+        0x1AB20A1234,
+        0x1,
+        0x190B11,
+        HardwareType.SH_PLUS,
+    ),
+    "=M000010.SN1234567890AFFW190011HW011": (
+        ModSn,
+        0x1234567890,
+        0xAF,
+        0x190011,
+        HardwareType.UPP,
+    ),
     # Name
     "=M000010.N1EG HWR Hau": (ModNameComment, "N", 0, "EG HWR Hau"),
     "=M000010.N2EG HWR Hau": (ModNameComment, "N", 1, "EG HWR Hau"),


### PR DESCRIPTION
- Add HardwareType Enum
- Incorporated HardwareType Enum in serial related methods.

Resolves: #35 

Example:
```python
module = pck_client.get_address_conn(LcnAddr(0, 7, False))  # automatically requests serials
await module.serial_known
print(f"Module: {module.hw_type.hw_name} ({module.hw_type.hw_id})")
```