### PR TITLE
Refresh the docs and add to tox

### DIFF
--- a/docs/source/api/connection.rst
+++ b/docs/source/api/connection.rst
@@ -2,18 +2,9 @@
 -----------------------
 
 .. automodule:: pypck.connection
-	
+
 .. autoclass:: PchkConnection
 	:members:
-		connect,
-		close,
-		send_command,
-		send_command_async,
-		process_input
-		
+
 .. autoclass:: PchkConnectionManager
 	:members:
-		connect,
-		get_lcn_connected,
-		is_ready,
-		get_address_conn

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -70,12 +70,12 @@ exclude_patterns = []
 pygments_style = 'default'
 
 
-# -- Options for HTML output -------------------------------------------------
+# -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'classic'
+html_theme = 'nature'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -86,17 +86,19 @@ html_theme = 'classic'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = []
+# html_static_path = ['_static']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
 #
-# The default sidebars (for documents that don't match any pattern) are
-# defined by theme itself.  Builtin themes are using these templates by
-# default: ``['localtoc.html', 'relations.html', 'sourcelink.html',
-# 'searchbox.html']``.
-#
-# html_sidebars = {}
+# This is required for the alabaster theme
+# refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
+html_sidebars = {
+    '**': [
+        'relations.html',  # needs 'show_related': True theme option to display
+        'searchbox.html',
+    ]
+}
 
 
 # -- Options for HTMLHelp output ---------------------------------------------

--- a/pypck/module.py
+++ b/pypck/module.py
@@ -1484,7 +1484,8 @@ class ModuleConnection(AbstractConnection):
         """Set the activation status for S0 variables.
 
         :param     bool    s0_enabled:   If True, a BU4L has to be connected
-        to the hardware module and S0 mode has to be activated in LCN-PRO.
+                                         to the hardware module and S0 mode
+                                         has to be activated in LCN-PRO.
         """
         self.has_s0_enabled = s0_enabled
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, format, lint, pylint, typing, cov
+envlist = py37, py38, format, lint, pylint, typing, cov, docs
 skip_missing_interpreters = True
 
 [testenv]
@@ -38,6 +38,12 @@ commands =
     pre-commit run mypy {posargs: --all-files}
 deps =
     -r{toxinidir}/requirements_test.txt
+
+[testenv:docs]
+commands =
+    sphinx-build -aEW -b html "docs/source" "docs/build"
+deps =
+    sphinx
 
 
 [pytest]


### PR DESCRIPTION
Fixes some doc build warnings and adds a docs build stage to tox.

@alengwenus I copied the docs styling from your private docs, i.e., nature instead of classic. It's obviously a matter of taste, but working with both docs consistency seems nice to me.  Also I don't see it hosted anywhere so I feel the impact to other users should be low. 

Anyway consider it a suggestion only and feel free to nuke the style change if you prefer the classic style.