### PR TITLE
Rework lcnaddr

### DIFF
--- a/pypck/connection.py
+++ b/pypck/connection.py
@@ -387,7 +387,7 @@ class PchkConnectionManager(PchkConnection):
                 address_conn = self.address_conns.pop(addr)
                 address_conn.seg_id = self.local_seg_id
                 self.address_conns[
-                    LcnAddr(self.local_seg_id, addr.get_id(), addr.is_group())
+                    LcnAddr(self.local_seg_id, addr.get_id(), addr.is_group)
                 ] = address_conn
 
     def physical_to_logical(self, addr: LcnAddr) -> LcnAddr:
@@ -402,7 +402,7 @@ class PchkConnectionManager(PchkConnection):
         return LcnAddr(
             self.local_seg_id if addr.get_seg_id() == 0 else addr.get_seg_id(),
             addr.get_id(),
-            addr.is_group(),
+            addr.is_group,
         )
 
     def is_ready(self) -> bool:
@@ -439,7 +439,7 @@ class PchkConnectionManager(PchkConnection):
             addr.seg_id = self.local_seg_id
         address_conn = self.address_conns.get(addr, None)
         if address_conn is None:
-            if addr.is_group():
+            if addr.is_group:
                 address_conn = GroupConnection(self, addr.seg_id, addr.addr_id)
             else:
                 address_conn = ModuleConnection(self, addr.seg_id, addr.addr_id)

--- a/pypck/connection.py
+++ b/pypck/connection.py
@@ -584,8 +584,8 @@ class PchkConnectionManager(PchkConnection):
         # Inputs from bus
         elif self.is_ready():
             assert isinstance(inp, inputs.ModInput)
-            inp.logical_source_addr = self.physical_to_logical(inp.physical_source_addr)
-            module_conn = self.get_address_conn(inp.logical_source_addr)
+            logical_source_addr = self.physical_to_logical(inp.physical_source_addr)
+            module_conn = self.get_address_conn(logical_source_addr)
             if isinstance(inp, inputs.ModSn):
                 if self.module_serial_number_received.locked():
                     self.module_serial_number_received.release()

--- a/pypck/connection.py
+++ b/pypck/connection.py
@@ -385,10 +385,10 @@ class PchkConnectionManager(PchkConnection):
         for addr in list(self.address_conns):
             if addr.seg_id == old_local_seg_id:
                 address_conn = self.address_conns.pop(addr)
-                address_conn.seg_id = self.local_seg_id
-                self.address_conns[
-                    LcnAddr(self.local_seg_id, addr.addr_id, addr.is_group)
-                ] = address_conn
+                address_conn.addr = LcnAddr(
+                    self.local_seg_id, addr.addr_id, addr.is_group
+                )
+                self.address_conns[address_conn.addr] = address_conn
 
     def physical_to_logical(self, addr: LcnAddr) -> LcnAddr:
         """Convert the physical segment id of an address to the logical one.
@@ -436,13 +436,13 @@ class PchkConnectionManager(PchkConnection):
         >>> module.toggle_output(0, 5)
         """
         if addr.seg_id == 0 and self.local_seg_id != -1:
-            addr.seg_id = self.local_seg_id
+            addr = LcnAddr(self.local_seg_id, addr.addr_id, addr.is_group)
         address_conn = self.address_conns.get(addr, None)
         if address_conn is None:
             if addr.is_group:
-                address_conn = GroupConnection(self, addr.seg_id, addr.addr_id)
+                address_conn = GroupConnection(self, addr)
             else:
-                address_conn = ModuleConnection(self, addr.seg_id, addr.addr_id)
+                address_conn = ModuleConnection(self, addr)
 
             self.address_conns[addr] = address_conn
 

--- a/pypck/connection.py
+++ b/pypck/connection.py
@@ -383,11 +383,11 @@ class PchkConnectionManager(PchkConnection):
         # replace all address_conns with current local_seg_id with new
         # local_seg_id
         for addr in list(self.address_conns):
-            if addr.get_seg_id() == old_local_seg_id:
+            if addr.seg_id == old_local_seg_id:
                 address_conn = self.address_conns.pop(addr)
                 address_conn.seg_id = self.local_seg_id
                 self.address_conns[
-                    LcnAddr(self.local_seg_id, addr.get_id(), addr.is_group)
+                    LcnAddr(self.local_seg_id, addr.addr_id, addr.is_group)
                 ] = address_conn
 
     def physical_to_logical(self, addr: LcnAddr) -> LcnAddr:
@@ -400,8 +400,8 @@ class PchkConnectionManager(PchkConnection):
         :rtype:      :class:`~LcnAddr`
         """
         return LcnAddr(
-            self.local_seg_id if addr.get_seg_id() == 0 else addr.get_seg_id(),
-            addr.get_id(),
+            self.local_seg_id if addr.seg_id == 0 else addr.seg_id,
+            addr.addr_id,
             addr.is_group,
         )
 
@@ -435,7 +435,7 @@ class PchkConnectionManager(PchkConnection):
         >>> module = pchk_connection.get_address_conn(address)
         >>> module.toggle_output(0, 5)
         """
-        if addr.get_seg_id() == 0 and self.local_seg_id != -1:
+        if addr.seg_id == 0 and self.local_seg_id != -1:
             addr.seg_id = self.local_seg_id
         address_conn = self.address_conns.get(addr, None)
         if address_conn is None:

--- a/pypck/inputs.py
+++ b/pypck/inputs.py
@@ -61,15 +61,6 @@ class ModInput(Input):
         """Construct ModInput object."""
         super().__init__()
         self.physical_source_addr = physical_source_addr
-        self.logical_source_addr = LcnAddr()
-
-    def get_logical_source_addr(self) -> LcnAddr:
-        """Return the logical source id.
-
-        :return:   Logical source address.
-        :rtype:    :class:`~pypck.lcn_addr.LcnAddr`
-        """
-        return self.logical_source_addr
 
 
 # ## Plain text inputs

--- a/pypck/lcn_addr.py
+++ b/pypck/lcn_addr.py
@@ -52,22 +52,7 @@ class LcnAddr:
 
     seg_id: int = -1
     addr_id: int = -1
-    _is_group: bool = False
-
-    def __init__(self, seg_id: int = -1, addr_id: int = -1, is_group: bool = False):
-        """Construct LcnAddr instance."""
-        self.seg_id = seg_id
-        self.addr_id = addr_id
-        self._is_group = is_group
-
-    def is_group(self) -> bool:
-        """Get the address' module or group id (discarding the concrete type).
-
-        :return:    Returns whether address points to a module(False) or
-                    group(True)
-        :rtype:     bool
-        """
-        return self._is_group
+    is_group: bool = False
 
     def get_seg_id(self) -> int:
         """Get the logical segment id.
@@ -104,7 +89,7 @@ class LcnAddr:
                     otherwise False
         :rtype:     bool
         """
-        if self.is_group():
+        if self.is_group:
             # seg_id:
             # 0 = Local, 1..2 = Not allowed (but "seen in the wild")
             # 3 = Broadcast, 4 = Status messages, 5..127, 128 = Segment-bus

--- a/pypck/lcn_addr.py
+++ b/pypck/lcn_addr.py
@@ -50,8 +50,8 @@ class LcnAddr:
                                 5..254)
     """
 
-    seg_id: int = -1
-    addr_id: int = -1
+    seg_id: int
+    addr_id: int
     is_group: bool = False
 
     def get_seg_id(self) -> int:

--- a/pypck/lcn_addr.py
+++ b/pypck/lcn_addr.py
@@ -13,7 +13,7 @@ Contributors:
 from dataclasses import dataclass
 
 
-@dataclass(unsafe_hash=True)
+@dataclass(frozen=True)
 class LcnAddr:
     """Represents a LCN address (module or group).
 

--- a/pypck/lcn_addr.py
+++ b/pypck/lcn_addr.py
@@ -10,7 +10,10 @@ Contributors:
   Tobias Juettner - initial LCN binding for openHAB (Java)
 """
 
+from dataclasses import dataclass
 
+
+@dataclass(unsafe_hash=True)
 class LcnAddr:
     """Represents a LCN address (module or group).
 
@@ -46,6 +49,10 @@ class LcnAddr:
                                 4 = Status messages,
                                 5..254)
     """
+
+    seg_id: int = -1
+    addr_id: int = -1
+    _is_group: bool = False
 
     def __init__(self, seg_id: int = -1, addr_id: int = -1, is_group: bool = False):
         """Construct LcnAddr instance."""
@@ -125,41 +132,3 @@ class LcnAddr:
                 & (self.addr_id <= 254)
             )
         return is_valid
-
-    def __hash__(self) -> int:
-        """Calculate and return hash value."""
-        if self.is_valid():
-            hash_value = (
-                (self.is_group() << 9)
-                + (reverse_uint8(self.get_id()) << 8)
-                + (reverse_uint8(self.get_seg_id()))
-            )
-        else:
-            hash_value = -1
-        return hash_value
-
-    def __eq__(self, obj: object) -> bool:
-        """Return if instance equals the given object."""
-        if not isinstance(obj, LcnAddr):
-            return False
-        return (
-            (self.is_group() == obj.is_group())
-            and (self.get_seg_id() == obj.get_seg_id())
-            and (self.get_id() == obj.get_id())
-        )
-
-
-# only execute, if not defined before
-if "REV_UINT8" not in dir():
-    REV_UINT8 = [0] * 256
-    for i in range(256):
-        for j in range(8):
-            if i & (1 << j) != 0:
-                REV_UINT8[i] |= 0x80 >> j
-
-
-def reverse_uint8(value: int) -> int:
-    """Reverse the bit order of the given value."""
-    if value < 0 | value > 255:
-        raise ValueError("Invalid value.")
-    return REV_UINT8[value]

--- a/pypck/lcn_addr.py
+++ b/pypck/lcn_addr.py
@@ -54,14 +54,6 @@ class LcnAddr:
     addr_id: int
     is_group: bool = False
 
-    def get_seg_id(self) -> int:
-        """Get the logical segment id.
-
-        :return:    The (logical) segment id
-        :rtype:     int
-        """
-        return self.seg_id
-
     def get_physical_seg_id(self, local_seg_id: int) -> int:
         """Get the physical segment id ("local" segment replaced with 0).
 
@@ -73,14 +65,6 @@ class LcnAddr:
         :rtype:     int
         """
         return 0 if (self.seg_id == local_seg_id) else self.seg_id
-
-    def get_id(self) -> int:
-        """Get the module id.
-
-        :return:    The module id
-        :rtype:     int
-        """
-        return self.addr_id
 
     def is_valid(self) -> bool:
         """Return if the current address is valid.

--- a/pypck/lcn_addr.py
+++ b/pypck/lcn_addr.py
@@ -65,39 +65,3 @@ class LcnAddr:
         :rtype:     int
         """
         return 0 if (self.seg_id == local_seg_id) else self.seg_id
-
-    def is_valid(self) -> bool:
-        """Return if the current address is valid.
-
-        :return:    True, if address is a valid group/module address,
-                    otherwise False
-        :rtype:     bool
-        """
-        if self.is_group:
-            # seg_id:
-            # 0 = Local, 1..2 = Not allowed (but "seen in the wild")
-            # 3 = Broadcast, 4 = Status messages, 5..127, 128 = Segment-bus
-            #     disabled (valid value)
-            # addr_id:
-            # 3 = Broadcast, 4 = Status messages, 5..254
-            is_valid = (
-                (self.seg_id >= 0)
-                & (self.seg_id <= 128)
-                & (self.addr_id >= 3)
-                & (self.addr_id <= 254)
-            )
-        else:
-            # seg_id:
-            # 0 = Local, 1..2 = Not allowed (but "seen in the wild")
-            # 3 = Broadcast, 4 = Status messages, 5..127, 128 = Segment-bus
-            #     disabled (valid value)
-            # addr_id:
-            # 1 = LCN-PRO, 2 = LCN-GVS/LCN-W, 4 = PCHK, 5..254, 255 = Unprog.
-            #     (valid, but irrelevant here)
-            is_valid = (
-                (self.seg_id >= 0)
-                & (self.seg_id <= 128)
-                & (self.addr_id >= 1)
-                & (self.addr_id <= 254)
-            )
-        return is_valid

--- a/pypck/module.py
+++ b/pypck/module.py
@@ -783,7 +783,7 @@ class AbstractConnection(LcnAddr):
         :rtype:      bool
         """
         return await self.send_command(
-            not self.is_group(), PckGenerator.dim_ouput(output_id, percent, ramp)
+            not self.is_group, PckGenerator.dim_ouput(output_id, percent, ramp)
         )
 
     async def dim_all_outputs(
@@ -800,7 +800,7 @@ class AbstractConnection(LcnAddr):
         :rtype:      bool
         """
         return await self.send_command(
-            not self.is_group(), PckGenerator.dim_all_outputs(percent, ramp, is1805)
+            not self.is_group, PckGenerator.dim_all_outputs(percent, ramp, is1805)
         )
 
     async def rel_output(self, output_id: int, percent: float) -> bool:
@@ -814,7 +814,7 @@ class AbstractConnection(LcnAddr):
         :rtype:      bool
         """
         return await self.send_command(
-            not self.is_group(), PckGenerator.rel_output(output_id, percent)
+            not self.is_group, PckGenerator.rel_output(output_id, percent)
         )
 
     async def toggle_output(self, output_id: int, ramp: int) -> bool:
@@ -829,7 +829,7 @@ class AbstractConnection(LcnAddr):
         :rtype:      bool
         """
         return await self.send_command(
-            not self.is_group(), PckGenerator.toggle_output(output_id, ramp)
+            not self.is_group, PckGenerator.toggle_output(output_id, ramp)
         )
 
     async def toggle_all_outputs(self, ramp: int) -> bool:
@@ -843,7 +843,7 @@ class AbstractConnection(LcnAddr):
         :rtype:      bool
         """
         return await self.send_command(
-            not self.is_group(), PckGenerator.toggle_all_outputs(ramp)
+            not self.is_group, PckGenerator.toggle_all_outputs(ramp)
         )
 
     async def control_relays(self, states: List[lcn_defs.RelayStateModifier]) -> bool:
@@ -856,7 +856,7 @@ class AbstractConnection(LcnAddr):
         :rtype:      bool
         """
         return await self.send_command(
-            not self.is_group(), PckGenerator.control_relays(states)
+            not self.is_group, PckGenerator.control_relays(states)
         )
 
     async def control_motors_relays(
@@ -871,7 +871,7 @@ class AbstractConnection(LcnAddr):
         :rtype:      bool
         """
         return await self.send_command(
-            not self.is_group(), PckGenerator.control_motors_relays(states)
+            not self.is_group, PckGenerator.control_motors_relays(states)
         )
 
     async def control_motors_outputs(
@@ -890,7 +890,7 @@ class AbstractConnection(LcnAddr):
         :rtype:      bool
         """
         return await self.send_command(
-            not self.is_group(),
+            not self.is_group,
             PckGenerator.control_motors_outputs(state, reverse_time),
         )
 
@@ -916,7 +916,7 @@ class AbstractConnection(LcnAddr):
         :rtype:      bool
         """
         success = await self.send_command(
-            not self.is_group(), PckGenerator.change_scene_register(register_id)
+            not self.is_group, PckGenerator.change_scene_register(register_id)
         )
         if not success:
             return False
@@ -925,14 +925,14 @@ class AbstractConnection(LcnAddr):
         if output_ports:
             coros.append(
                 self.send_command(
-                    not self.is_group(),
+                    not self.is_group,
                     PckGenerator.activate_scene_output(scene_id, output_ports, ramp),
                 )
             )
         if relay_ports:
             coros.append(
                 self.send_command(
-                    not self.is_group(),
+                    not self.is_group,
                     PckGenerator.activate_scene_relay(scene_id, relay_ports),
                 )
             )
@@ -961,7 +961,7 @@ class AbstractConnection(LcnAddr):
         :rtype:      bool
         """
         success = await self.send_command(
-            not self.is_group(), PckGenerator.change_scene_register(register_id)
+            not self.is_group, PckGenerator.change_scene_register(register_id)
         )
 
         if not success:
@@ -971,14 +971,14 @@ class AbstractConnection(LcnAddr):
         if output_ports:
             coros.append(
                 self.send_command(
-                    not self.is_group(),
+                    not self.is_group,
                     PckGenerator.store_scene_output(scene_id, output_ports, ramp),
                 )
             )
         if relay_ports:
             coros.append(
                 self.send_command(
-                    not self.is_group(),
+                    not self.is_group,
                     PckGenerator.store_scene_relay(scene_id, relay_ports),
                 )
             )
@@ -1015,27 +1015,27 @@ class AbstractConnection(LcnAddr):
 
         if lcn_defs.Var.to_var_id(var) != -1:
             # Absolute commands for variables 1-12 are not supported
-            if self.get_id() == 4 and self.is_group():
+            if self.get_id() == 4 and self.is_group:
                 # group 4 are status messages
                 return await self.send_command(
-                    not self.is_group(),
+                    not self.is_group,
                     PckGenerator.update_status_var(var, value.to_native()),
                 )
             # We fake the missing command by using reset and relative
             # commands.
             success = await self.send_command(
-                not self.is_group(), PckGenerator.var_reset(var, sw_is2013)
+                not self.is_group, PckGenerator.var_reset(var, sw_is2013)
             )
             if not success:
                 return False
             return await self.send_command(
-                not self.is_group(),
+                not self.is_group,
                 PckGenerator.var_rel(
                     var, lcn_defs.RelVarRef.CURRENT, value.to_native(), sw_is2013
                 ),
             )
         return await self.send_command(
-            not self.is_group(), PckGenerator.var_abs(var, value.to_native())
+            not self.is_group, PckGenerator.var_abs(var, value.to_native())
         )
 
     async def var_reset(self, var: lcn_defs.Var, is2013: Optional[bool] = None) -> bool:
@@ -1054,7 +1054,7 @@ class AbstractConnection(LcnAddr):
             sw_is2013 = False
 
         return await self.send_command(
-            not self.is_group(), PckGenerator.var_reset(var, sw_is2013)
+            not self.is_group, PckGenerator.var_reset(var, sw_is2013)
         )
 
     async def var_rel(
@@ -1088,7 +1088,7 @@ class AbstractConnection(LcnAddr):
             sw_is2013 = False
 
         return await self.send_command(
-            not self.is_group(),
+            not self.is_group,
             PckGenerator.var_rel(var, value_ref, value.to_native(), sw_is2013),
         )
 
@@ -1103,7 +1103,7 @@ class AbstractConnection(LcnAddr):
         :rtype:      bool
         """
         return await self.send_command(
-            not self.is_group(), PckGenerator.lock_regulator(reg_id, state)
+            not self.is_group, PckGenerator.lock_regulator(reg_id, state)
         )
 
     async def control_led(
@@ -1115,7 +1115,7 @@ class AbstractConnection(LcnAddr):
         :param    LedStatus    state:      Led status
         """
         return await self.send_command(
-            not self.is_group(), PckGenerator.control_led(led.value, state)
+            not self.is_group, PckGenerator.control_led(led.value, state)
         )
 
     async def send_keys(
@@ -1138,7 +1138,7 @@ class AbstractConnection(LcnAddr):
                 cmds[table_id] = cmd
                 coros.append(
                     self.send_command(
-                        not self.is_group(), PckGenerator.send_keys(cmds, key_states)
+                        not self.is_group, PckGenerator.send_keys(cmds, key_states)
                     )
                 )
         results = await asyncio.gather(*coros)
@@ -1164,7 +1164,7 @@ class AbstractConnection(LcnAddr):
             if True in key_states:
                 coros.append(
                     self.send_command(
-                        not self.is_group(),
+                        not self.is_group,
                         PckGenerator.send_keys_hit_deferred(
                             table_id, delay_time, delay_unit, key_states
                         ),
@@ -1186,7 +1186,7 @@ class AbstractConnection(LcnAddr):
         :rtype:      bool
         """
         return await self.send_command(
-            not self.is_group(), PckGenerator.lock_keys(table_id, states)
+            not self.is_group, PckGenerator.lock_keys(table_id, states)
         )
 
     async def lock_keys_tab_a_temporary(
@@ -1203,7 +1203,7 @@ class AbstractConnection(LcnAddr):
         :rtype:      bool
         """
         return await self.send_command(
-            not self.is_group(),
+            not self.is_group,
             PckGenerator.lock_keys_tab_a_temporary(delay_time, delay_unit, states),
         )
 
@@ -1223,7 +1223,7 @@ class AbstractConnection(LcnAddr):
             if part:
                 coros.append(
                     self.send_command(
-                        not self.is_group(),
+                        not self.is_group,
                         PckGenerator.dyn_text_part(row_id, part_id, part),
                     )
                 )
@@ -1240,7 +1240,7 @@ class AbstractConnection(LcnAddr):
         :rtype:      bool
         """
         return await self.send_command(
-            not self.is_group(), PckGenerator.beep(sound, count)
+            not self.is_group, PckGenerator.beep(sound, count)
         )
 
     async def ping(self) -> bool:
@@ -1255,7 +1255,7 @@ class AbstractConnection(LcnAddr):
         :returns:    True if command was sent successfully, False otherwise
         :rtype:      bool
         """
-        return await self.send_command(not self.is_group(), pck)
+        return await self.send_command(not self.is_group, pck)
 
 
 class GroupConnection(AbstractConnection):

--- a/pypck/pck_commands.py
+++ b/pypck/pck_commands.py
@@ -245,7 +245,7 @@ class PckGenerator:
         return ">{:s}{:03d}{:03d}{:s}".format(
             "G" if addr.is_group else "M",
             addr.get_physical_seg_id(local_seg_id),
-            addr.get_id(),
+            addr.addr_id,
             "!" if wants_ack else ".",
         )
 

--- a/pypck/pck_commands.py
+++ b/pypck/pck_commands.py
@@ -243,7 +243,7 @@ class PckGenerator:
         :rtype:     str
         """
         return ">{:s}{:03d}{:03d}{:s}".format(
-            "G" if addr.is_group() else "M",
+            "G" if addr.is_group else "M",
             addr.get_physical_seg_id(local_seg_id),
             addr.get_id(),
             "!" if wants_ack else ".",


### PR DESCRIPTION
Rework `LcnAddr` as frozen dataclass to get automatic generation of all special members `(__init__, __eq__, __repr__, __hash__)`. Provides also better safety when LcnAddr is used as key in a dict, since modifications are disallowed.

One step in the direction of making `LcnAddr` handling more "pythonic" (#8), but maybe only the first step.

BTW. The is_valid method is unused. I guess it serves as extra documentation what kind of addresses can/should be used. OTOH the same text is included in the docstring.  So its all duplicate anyway.  I'm still contemplating to remove it.

@alengwenus Do you have a preference or a use case for the is_valid() check in mind?