### PR TITLE
Unify handling of firmware version arguments in pck commands

### DIFF
--- a/pypck/module.py
+++ b/pypck/module.py
@@ -804,20 +804,21 @@ class AbstractConnection:
         )
 
     async def dim_all_outputs(
-        self, percent: float, ramp: int, is1805: bool = False
+        self, percent: float, ramp: int, sw_age: Optional[int] = None
     ) -> bool:
         """Send a dim command for all output-ports.
 
-        :param    float    percent:    Brightness in percent 0..100
+        :param    float  percent:    Brightness in percent 0..100
         :param    int    ramp:       Ramp time in milliseconds.
-        :param    bool   is1805:     True if the target module's firmware is
-                                     180501 or newer, otherwise False
+        :param    int    sw_age:     The minimum firmware version expected by
+                                     any receiving module.
 
         :returns:    True if command was sent successfully, False otherwise
         :rtype:      bool
         """
+        swa = sw_age or (self._sw_age or 0)
         return await self.send_command(
-            not self.is_group, PckGenerator.dim_all_outputs(percent, ramp, is1805)
+            not self.is_group, PckGenerator.dim_all_outputs(percent, ramp, swa)
         )
 
     async def rel_output(self, output_id: int, percent: float) -> bool:
@@ -1023,7 +1024,7 @@ class AbstractConnection:
         var: lcn_defs.Var,
         value_or_float: Union[float, lcn_defs.VarValue],
         unit: lcn_defs.VarUnit = lcn_defs.VarUnit.NATIVE,
-        is2013: Optional[bool] = None,
+        sw_age: Optional[int] = None,
     ) -> bool:
         """Send a command to set the absolute value to a variable.
 
@@ -1039,12 +1040,7 @@ class AbstractConnection:
         else:
             value = lcn_defs.VarValue.from_var_unit(value_or_float, unit, True)
 
-        if is2013 is not None:
-            sw_is2013 = is2013
-        elif self._sw_age is not None:
-            sw_is2013 = self._sw_age >= 0x170206
-        else:
-            sw_is2013 = False
+        swa = sw_age or (self._sw_age or 0)
 
         if lcn_defs.Var.to_var_id(var) != -1:
             # Absolute commands for variables 1-12 are not supported
@@ -1057,21 +1053,21 @@ class AbstractConnection:
             # We fake the missing command by using reset and relative
             # commands.
             success = await self.send_command(
-                not self.is_group, PckGenerator.var_reset(var, sw_is2013)
+                not self.is_group, PckGenerator.var_reset(var, swa)
             )
             if not success:
                 return False
             return await self.send_command(
                 not self.is_group,
                 PckGenerator.var_rel(
-                    var, lcn_defs.RelVarRef.CURRENT, value.to_native(), sw_is2013
+                    var, lcn_defs.RelVarRef.CURRENT, value.to_native(), swa
                 ),
             )
         return await self.send_command(
             not self.is_group, PckGenerator.var_abs(var, value.to_native())
         )
 
-    async def var_reset(self, var: lcn_defs.Var, is2013: Optional[bool] = None) -> bool:
+    async def var_reset(self, var: lcn_defs.Var, sw_age: Optional[int] = None) -> bool:
         """Send a command to reset the variable value.
 
         :param    Var    var:    Variable
@@ -1079,15 +1075,9 @@ class AbstractConnection:
         :returns:    True if command was sent successfully, False otherwise
         :rtype:      bool
         """
-        if is2013 is not None:
-            sw_is2013 = is2013
-        elif self._sw_age is not None:
-            sw_is2013 = self._sw_age >= 0x170206
-        else:
-            sw_is2013 = False
-
+        swa = sw_age or (self._sw_age or 0)
         return await self.send_command(
-            not self.is_group, PckGenerator.var_reset(var, sw_is2013)
+            not self.is_group, PckGenerator.var_reset(var, swa)
         )
 
     async def var_rel(
@@ -1096,7 +1086,7 @@ class AbstractConnection:
         value_or_float: Union[float, lcn_defs.VarValue],
         unit: lcn_defs.VarUnit = lcn_defs.VarUnit.NATIVE,
         value_ref: lcn_defs.RelVarRef = lcn_defs.RelVarRef.CURRENT,
-        is2013: Optional[bool] = None,
+        sw_age: Optional[int] = None,
     ) -> bool:
         """Send a command to change the value of a variable.
 
@@ -1113,16 +1103,11 @@ class AbstractConnection:
         else:
             value = lcn_defs.VarValue.from_var_unit(value_or_float, unit, True)
 
-        if is2013 is not None:
-            sw_is2013 = is2013
-        elif self._sw_age is not None:
-            sw_is2013 = self._sw_age >= 0x170206
-        else:
-            sw_is2013 = False
+        swa = sw_age or (self._sw_age or 0)
 
         return await self.send_command(
             not self.is_group,
-            PckGenerator.var_rel(var, value_ref, value.to_native(), sw_is2013),
+            PckGenerator.var_rel(var, value_ref, value.to_native(), swa),
         )
 
     async def lock_regulator(self, reg_id: int, state: bool) -> bool:
@@ -1312,7 +1297,7 @@ class GroupConnection(AbstractConnection):
         var: lcn_defs.Var,
         value: Union[float, lcn_defs.VarValue],
         unit: lcn_defs.VarUnit = lcn_defs.VarUnit.NATIVE,
-        is2013: Optional[bool] = None,
+        sw_age: Optional[int] = None,
     ) -> bool:
         """Send a command to set the absolute value to a variable.
 
@@ -1322,7 +1307,7 @@ class GroupConnection(AbstractConnection):
         """
         coros = []
         # for new modules (>=0x170206)
-        coros.append(super().var_abs(var, value, unit, is2013=True))
+        coros.append(super().var_abs(var, value, unit, 0x170206))
 
         # for old modules (<0x170206)
         if var in [
@@ -1332,17 +1317,17 @@ class GroupConnection(AbstractConnection):
             lcn_defs.Var.R1VARSETPOINT,
             lcn_defs.Var.R2VARSETPOINT,
         ]:
-            coros.append(super().var_abs(var, value, unit, is2013=False))
+            coros.append(super().var_abs(var, value, unit, 0x000000))
         results = await asyncio.gather(*coros)
         return all(results)
 
-    async def var_reset(self, var: lcn_defs.Var, is2013: Optional[bool] = None) -> bool:
+    async def var_reset(self, var: lcn_defs.Var, sw_age: Optional[int] = None) -> bool:
         """Send a command to reset the variable value.
 
         :param    Var    var:    Variable
         """
         coros = []
-        coros.append(super().var_reset(var, is2013=True))
+        coros.append(super().var_reset(var, 0x170206))
         if var in [
             lcn_defs.Var.TVAR,
             lcn_defs.Var.R1VAR,
@@ -1350,7 +1335,7 @@ class GroupConnection(AbstractConnection):
             lcn_defs.Var.R1VARSETPOINT,
             lcn_defs.Var.R2VARSETPOINT,
         ]:
-            coros.append(super().var_reset(var, is2013=False))
+            coros.append(super().var_reset(var, 0))
         results = await asyncio.gather(*coros)
         return all(results)
 
@@ -1360,7 +1345,7 @@ class GroupConnection(AbstractConnection):
         value: Union[float, lcn_defs.VarValue],
         unit: lcn_defs.VarUnit = lcn_defs.VarUnit.NATIVE,
         value_ref: lcn_defs.RelVarRef = lcn_defs.RelVarRef.CURRENT,
-        is2013: Optional[bool] = None,
+        sw_age: Optional[int] = None,
     ) -> bool:
         """Send a command to change the value of a variable.
 
@@ -1370,7 +1355,7 @@ class GroupConnection(AbstractConnection):
         :param     VarUnit    unit:     Unit of variable
         """
         coros = []
-        coros.append(super().var_rel(var, value, is2013=True))
+        coros.append(super().var_rel(var, value, sw_age=0x170206))
         if var in [
             lcn_defs.Var.TVAR,
             lcn_defs.Var.R1VAR,
@@ -1383,7 +1368,7 @@ class GroupConnection(AbstractConnection):
             lcn_defs.Var.THRS4,
             lcn_defs.Var.THRS5,
         ]:
-            coros.append(super().var_rel(var, value, is2013=False))
+            coros.append(super().var_rel(var, value, sw_age=0))
         results = await asyncio.gather(*coros)
         return all(results)
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -100,12 +100,12 @@ COMMANDS = {
         f"O{output+1:d}DI101123": (PckGenerator.dim_output, output, 50.5, 123)
         for output in range(4)
     },
-    "OY100100100100123": (PckGenerator.dim_all_outputs, 50.0, 123, True),
-    "OY000000000000123": (PckGenerator.dim_all_outputs, 0.0, 123, True),
-    "OY200200200200123": (PckGenerator.dim_all_outputs, 100.0, 123, True),
-    "AA123": (PckGenerator.dim_all_outputs, 0.0, 123),
-    "AE123": (PckGenerator.dim_all_outputs, 100.0, 123),
-    "AH050": (PckGenerator.dim_all_outputs, 50.0, 123),
+    "OY100100100100123": (PckGenerator.dim_all_outputs, 50.0, 123, 0x180501),
+    "OY000000000000123": (PckGenerator.dim_all_outputs, 0.0, 123, 0x180501),
+    "OY200200200200123": (PckGenerator.dim_all_outputs, 100.0, 123, 0x180501),
+    "AA123": (PckGenerator.dim_all_outputs, 0.0, 123, 0x180500),
+    "AE123": (PckGenerator.dim_all_outputs, 100.0, 123, 0x180500),
+    "AH050": (PckGenerator.dim_all_outputs, 50.0, 123, 0x180500),
     **{
         f"A{output+1:d}AD050": (PckGenerator.rel_output, output, 50.0)
         for output in range(4)
@@ -218,22 +218,22 @@ COMMANDS = {
     },
     "X2030044129": (PckGenerator.var_abs, Var.R1VARSETPOINT, 4201),
     "X2030108129": (PckGenerator.var_abs, Var.R2VARSETPOINT, 4201),
-    "X2030032000": (PckGenerator.var_reset, Var.R1VARSETPOINT),
-    "X2030096000": (PckGenerator.var_reset, Var.R2VARSETPOINT),
-    "ZS30000": (PckGenerator.var_reset, Var.TVAR, False),
+    "X2030032000": (PckGenerator.var_reset, Var.R1VARSETPOINT, 0x170206),
+    "X2030096000": (PckGenerator.var_reset, Var.R2VARSETPOINT, 0x170206),
+    "ZS30000": (PckGenerator.var_reset, Var.TVAR, 0x170205),
     **{
-        f"Z-{var.value + 1:03d}4090": (PckGenerator.var_reset, var)
+        f"Z-{var.value + 1:03d}4090": (PckGenerator.var_reset, var, 0x170206)
         for var in Var.variables
     },
-    "ZA23423": (PckGenerator.var_rel, Var.TVAR, RelVarRef.CURRENT, 23423, False),
-    "ZS23423": (PckGenerator.var_rel, Var.TVAR, RelVarRef.CURRENT, -23423, False),
+    "ZA23423": (PckGenerator.var_rel, Var.TVAR, RelVarRef.CURRENT, 23423, 0x170205),
+    "ZS23423": (PckGenerator.var_rel, Var.TVAR, RelVarRef.CURRENT, -23423, 0x170205),
     **{
         f"Z-{var.value + 1:03d}3000": (
             PckGenerator.var_rel,
             var,
             RelVarRef.CURRENT,
             -3000,
-            True,
+            0x170206,
         )
         for var in Var.variables
         if var != Var.TVAR
@@ -244,11 +244,11 @@ COMMANDS = {
             var,
             ref,
             -500,
-            new,
+            sw_age,
         )
         for nvar, var in enumerate(Var.set_points)
         for nref, ref in enumerate(RelVarRef)
-        for new in (True, False)
+        for sw_age in (0x170206, 0x170205)
     },
     **{
         f"RE{('A','B')[nvar]}S{('A','P')[nref]}+500": (
@@ -256,11 +256,11 @@ COMMANDS = {
             var,
             ref,
             500,
-            new,
+            sw_age,
         )
         for nvar, var in enumerate(Var.set_points)
         for nref, ref in enumerate(RelVarRef)
-        for new in (True, False)
+        for sw_age in (0x170206, 0x170205)
     },
     **{
         f"SS{('R','E')[nref]}0500SR{r+1}{i+1}": (
@@ -268,7 +268,7 @@ COMMANDS = {
             Var.thresholds[r][i],
             ref,
             -500,
-            True,
+            0x170206,
         )
         for r in range(4)
         for i in range(4)
@@ -280,7 +280,7 @@ COMMANDS = {
             Var.thresholds[r][i],
             ref,
             500,
-            True,
+            0x170206,
         )
         for r in range(4)
         for i in range(4)
@@ -292,7 +292,7 @@ COMMANDS = {
             Var.thresholds[0][i],
             ref,
             -500,
-            False,
+            0x170205,
         )
         for i in range(5)
         for nref, ref in enumerate(RelVarRef)
@@ -303,7 +303,7 @@ COMMANDS = {
             Var.thresholds[0][i],
             ref,
             500,
-            False,
+            0x170205,
         )
         for i in range(5)
         for nref, ref in enumerate(RelVarRef)


### PR DESCRIPTION
`The convenience commands in `module.py` and the `PckGenerator` functions handle module firmware based differences in pck command strings with various boolean flags, e.g. `is2013 = True` or `is1805 = False`. Unify the handling of firmware based differences by passing the firmware version directly yo the functions.