### PR TITLE
Update setup.py, fix (not working) exclude mask

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/alengwenus/pypck",
-    packages=setuptools.find_packages(exclude=("tests",)),
+    packages=setuptools.find_packages(exclude=(["tests","tests.*"])),
     install_requires=[],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
```
>>> Emerging (1 of 1) dev-python/pypck-0.7.6::HomeAssistantRepository
>>> Failed to emerge dev-python/pypck-0.7.6, Log file:
>>>  '/var/tmp/portage/dev-python/pypck-0.7.6/temp/build.log'
>>> Jobs: 0 of 1 complete, 1 failed                 Load avg: 0.75, 0.54, 0.35
 * Package:    dev-python/pypck-0.7.6
 * Repository: HomeAssistantRepository
 * Maintainer: b@edevau.net
 * Upstream:   alengwenus@gmail.com
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python3_8 test userland_GNU
 * FEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
...
running install_egg_info
running egg_info
writing pypck.egg-info/PKG-INFO
writing dependency_links to pypck.egg-info/dependency_links.txt
writing top-level names to pypck.egg-info/top_level.txt
reading manifest file 'pypck.egg-info/SOURCES.txt'
writing manifest file 'pypck.egg-info/SOURCES.txt'
Copying pypck.egg-info to /var/tmp/portage/dev-python/pypck-0.7.6/image/_python3.8/usr/lib/python3.8/site-packages/pypck-0.7.6-py3.8.egg-info
running install_scripts
 * ERROR: dev-python/pypck-0.7.6::HomeAssistantRepository failed (install phase):
 *   Package installs 'tests' package which is forbidden and likely a bug in the build system.
 *
 * Call stack:
 *     ebuild.sh, line  125:  Called src_install
 *   environment, line 2966:  Called distutils-r1_src_install
 *   environment, line 1193:  Called _distutils-r1_run_foreach_impl 'distutils-r1_python_install'
 *   environment, line  440:  Called python_foreach_impl 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2582:  Called multibuild_foreach_variant '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2064:  Called _multibuild_run '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2062:  Called _python_multibuild_wrapper 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line  797:  Called distutils-r1_run_phase 'distutils-r1_python_install'
 *   environment, line 1161:  Called distutils-r1_python_install
 *   environment, line 1080:  Called die
 * The specific snippet of code:
 *               die "Package installs '${p}' package which is forbidden and likely a bug in the build system.";
```