### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setuptools.setup(
     url="https://github.com/alengwenus/pypck",
     packages=setuptools.find_packages(exclude=(["tests", "tests.*"])),
     install_requires=[],
+    license="EPL-2.0",
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)",


### PR DESCRIPTION
Allow tools (e.g., PyPI or `pyp2rpm`) to get the license name.