### PR TITLE
Migrate asynctest to stdlib's AsyncMock

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
 
 env:
   CACHE_VERSION: 1
-  DEFAULT_PYTHON: 3.7
+  DEFAULT_PYTHON: 3.8
   PRE_COMMIT_HOME: ~/.cache/pre-commit
 
 jobs:
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v2
@@ -64,20 +64,17 @@ jobs:
     name: Check black
     runs-on: ubuntu-latest
     needs: prepare-tests
-    strategy:
-      matrix:
-        python-version: [3.7]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v2
-      - name: Restore Python virtual environment
+      - name: Restore Python ${{ env.DEFAULT_PYTHON }} virtual environment
         id: cache-venv
         uses: actions/cache@v2
         with:
           path: venv
           key: >-
             ${{ env.CACHE_VERSION }}-${{ runner.os }}-venv-${{
-            matrix.python-version }}-${{
+            env.DEFAULT_PYTHON }}-${{
             hashFiles('requirements_test.txt') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -93,20 +90,17 @@ jobs:
     name: Check pylint
     runs-on: ubuntu-latest
     needs: prepare-tests
-    strategy:
-      matrix:
-        python-version: [3.7]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v2
-      - name: Restore Python virtual environment
+      - name: Restore Python ${{ env.DEFAULT_PYTHON }} virtual environment
         id: cache-venv
         uses: actions/cache@v2
         with:
           path: venv
           key: >-
             ${{ env.CACHE_VERSION }}-${{ runner.os }}-venv-${{
-            matrix.python-version }}-${{
+            env.DEFAULT_PYTHON }}-${{
             hashFiles('requirements_test.txt') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -122,20 +116,17 @@ jobs:
     name: Check mypy
     runs-on: ubuntu-latest
     needs: prepare-tests
-    strategy:
-      matrix:
-        python-version: [3.7]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v2
-      - name: Restore Python virtual environment
+      - name: Restore Python ${{ env.DEFAULT_PYTHON }} virtual environment
         id: cache-venv
         uses: actions/cache@v2
         with:
           path: venv
           key: >-
             ${{ env.CACHE_VERSION }}-${{ runner.os }}-venv-${{
-            matrix.python-version }}-${{
+            env.DEFAULT_PYTHON }}-${{
             hashFiles('requirements_test.txt') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -151,20 +142,17 @@ jobs:
     name: Check codespell
     runs-on: ubuntu-latest
     needs: prepare-tests
-    strategy:
-      matrix:
-        python-version: [3.7]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v2
-      - name: Restore Python virtual environment
+      - name: Restore Python ${{ env.DEFAULT_PYTHON }} virtual environment
         id: cache-venv
         uses: actions/cache@v2
         with:
           path: venv
           key: >-
             ${{ env.CACHE_VERSION }}-${{ runner.os }}-venv-${{
-            matrix.python-version }}-${{
+            env.DEFAULT_PYTHON }}-${{
             hashFiles('requirements_test.txt') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -192,20 +180,17 @@ jobs:
     name: Check flake8
     runs-on: ubuntu-latest
     needs: prepare-tests
-    strategy:
-      matrix:
-        python-version: [3.7]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v2
-      - name: Restore Python virtual environment
+      - name: Restore Python ${{ env.DEFAULT_PYTHON }} virtual environment
         id: cache-venv
         uses: actions/cache@v2
         with:
           path: venv
           key: >-
             ${{ env.CACHE_VERSION }}-${{ runner.os }}-venv-${{
-            matrix.python-version }}-${{
+            env.DEFAULT_PYTHON }}-${{
             hashFiles('requirements_test.txt') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -233,20 +218,17 @@ jobs:
     name: Check pyupgrade
     runs-on: ubuntu-latest
     needs: prepare-tests
-    strategy:
-      matrix:
-        python-version: [3.7]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v2
-      - name: Restore Python virtual environment
+      - name: Restore Python ${{ env.DEFAULT_PYTHON }} virtual environment
         id: cache-venv
         uses: actions/cache@v2
         with:
           path: venv
           key: >-
             ${{ env.CACHE_VERSION }}-${{ runner.os }}-venv-${{
-            matrix.python-version }}-${{
+            env.DEFAULT_PYTHON }}-${{
             hashFiles('requirements_test.txt') }}
       - name: Fail job if Python cache restore failed
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -275,7 +257,7 @@ jobs:
     needs: prepare-tests
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
     name: Run tests Python ${{ matrix.python-version }}
     steps:
       - name: Check out code from GitHub

--- a/tests/messages/test_input_flow.py
+++ b/tests/messages/test_input_flow.py
@@ -1,10 +1,14 @@
 """Test the data flow for Input objects."""
-
+import sys
 from unittest.mock import patch
 
-import asynctest
 import pytest
 from pypck.inputs import Input
+
+if sys.version_info.minor >= 8:
+    from unittest.mock import AsyncMock
+else:
+    from asynctest.mock import CoroutineMock as AsyncMock
 
 
 @pytest.mark.asyncio
@@ -12,7 +16,7 @@ async def test_message_to_input(pypck_client):
     """Test data flow from message to input."""
     inp = Input()
     message = "dummy_message"
-    pypck_client.async_process_input = asynctest.CoroutineMock()
+    pypck_client.async_process_input = AsyncMock()
     with patch("pypck.inputs.InputParser.parse", return_value=[inp]) as inp_parse:
         await pypck_client.process_message(message)
 

--- a/tests/messages/test_output_status.py
+++ b/tests/messages/test_output_status.py
@@ -1,8 +1,15 @@
 """Tests for output status messages."""
 
-import asynctest
+import sys
+
 import pytest
 from pypck.inputs import InputParser, ModStatusOutput, ModStatusOutputNative
+
+if sys.version_info.minor >= 8:
+    from unittest.mock import AsyncMock
+else:
+    from asynctest.mock import CoroutineMock as AsyncMock
+
 
 # Unit tests
 
@@ -53,7 +60,7 @@ def test_parse_message_native(pck, expected):
 @pytest.mark.asyncio
 async def test_output_status(pchk_server, pypck_client, module10):
     """Output status command."""
-    module10.async_process_input = asynctest.CoroutineMock()
+    module10.async_process_input = AsyncMock()
     await pypck_client.async_connect()
 
     message = ":M000010A1050"

--- a/tests/messages/test_send_command_host.py
+++ b/tests/messages/test_send_command_host.py
@@ -1,8 +1,15 @@
 """Tests for send command host."""
 
-import asynctest
+import sys
+
 import pytest
 from pypck.inputs import InputParser, ModSendCommandHost
+
+if sys.version_info.minor >= 8:
+    from unittest.mock import AsyncMock
+else:
+    from asynctest.mock import CoroutineMock as AsyncMock
+
 
 # Unit tests
 
@@ -48,7 +55,7 @@ def test_parse_message_percent(pck, expected):
 @pytest.mark.asyncio
 async def test_send_command_host(pchk_server, pypck_client, module10):
     """Send command host message."""
-    module10.async_process_input = asynctest.CoroutineMock()
+    module10.async_process_input = AsyncMock()
     await pypck_client.async_connect()
 
     message = "+M004000010.SKH001002"

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,12 +1,17 @@
 """Connection tests."""
-
 import asyncio
+import sys
 
-import asynctest
 import pytest
 from pypck.connection import PchkAuthenticationError, PchkLicenseError
 from pypck.lcn_addr import LcnAddr
 from pypck.module import ModuleConnection
+
+if sys.version_info.minor >= 8:
+    from unittest.mock import AsyncMock, call
+else:
+    from asynctest.mock import CoroutineMock as AsyncMock
+    from asynctest.mock import call
 
 
 @pytest.mark.asyncio
@@ -57,48 +62,40 @@ async def test_timeout_error(pchk_server, pypck_client):
 @pytest.mark.asyncio
 async def test_lcn_connected(pchk_server, pypck_client):
     """Test lcn disconnected event."""
-    pypck_client.event_handler = asynctest.CoroutineMock()
+    pypck_client.event_handler = AsyncMock()
     await pypck_client.async_connect()
     await pchk_server.send_message("$io:#LCN:connected")
     await pypck_client.received("$io:#LCN:connected")
 
     pypck_client.event_handler.assert_has_awaits(
-        [
-            asynctest.mock.call("lcn-connection-status-changed"),
-            asynctest.mock.call("lcn-connected"),
-        ]
+        [call("lcn-connection-status-changed"), call("lcn-connected")]
     )
 
 
 @pytest.mark.asyncio
 async def test_lcn_disconnected(pchk_server, pypck_client):
     """Test lcn disconnected event."""
-    pypck_client.event_handler = asynctest.CoroutineMock()
+    pypck_client.event_handler = AsyncMock()
     await pypck_client.async_connect()
     await pchk_server.send_message("$io:#LCN:disconnected")
     await pypck_client.received("$io:#LCN:disconnected")
 
     pypck_client.event_handler.assert_has_awaits(
-        [
-            asynctest.mock.call("lcn-connection-status-changed"),
-            asynctest.mock.call("lcn-disconnected"),
-        ]
+        [call("lcn-connection-status-changed"), call("lcn-disconnected")]
     )
 
 
 @pytest.mark.asyncio
 async def test_connection_lost(pchk_server, pypck_client):
     """Test pchk server connection close."""
-    pypck_client.event_handler = asynctest.CoroutineMock()
+    pypck_client.event_handler = AsyncMock()
     await pypck_client.async_connect()
 
     await pchk_server.stop()
     # ensure that pypck_client is about to be closed
     await pypck_client.wait_closed()
 
-    pypck_client.event_handler.assert_has_awaits(
-        [asynctest.mock.call("connection-lost")]
-    )
+    pypck_client.event_handler.assert_has_awaits([call("connection-lost")])
 
 
 @pytest.mark.asyncio

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, format, lint, pylint, typing, cov, docs
+envlist = py37, py38, py39, format, lint, pylint, typing, cov, docs
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
- Use unittest.mock.AsyncMock in tests for Python >3.8
- Add test environment for Python 3.9

Resolves: #60 