### PR TITLE
Fix lost serial request tasks

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -249,3 +249,23 @@ async def test_groups_membership_discovery(pchk_server, pypck_client):
         LcnAddr(0, 100, True),
         LcnAddr(0, 52, True),
     }
+
+
+@pytest.mark.asyncio
+async def test_multiple_serial_requests(pchk_server, pypck_client):
+    """Test module scan."""
+    await pypck_client.async_connect()
+
+    pypck_client.get_address_conn(LcnAddr(0, 10, False))
+    pypck_client.get_address_conn(LcnAddr(0, 11, False))
+    pypck_client.get_address_conn(LcnAddr(0, 12, False))
+
+    assert await pchk_server.received(">M000010.SN")
+    assert await pchk_server.received(">M000011.SN")
+    assert await pchk_server.received(">M000012.SN")
+
+    message = "=M000010.SN1AB20A123401FW190B11HW015"
+    await pchk_server.send_message(message)
+    assert await pypck_client.received(message)
+
+    await pypck_client.async_close()


### PR DESCRIPTION
PchkConnectionManager overwrites the `request_serials_task`. Fix it by collecting all `request_serials` tasks and regularly awaiting those that are done in process_input. An alternative place for doing the regular cleanup work would be either the ping task or a new separate periodic cleanup task.

@alengwenus If you prefer any of the two other options, just let me know. Shouldn't be pretty simple to change it.

The included test issues a warning about a task that was not awaited without the fix.