### PR TITLE
Add module info dumping

### DIFF
--- a/pypck/connection.py
+++ b/pypck/connection.py
@@ -518,6 +518,17 @@ class PchkConnectionManager(PchkConnection):
             return self.get_group_conn(addr)
         return self.get_module_conn(addr, request_serials)
 
+    def dump_modules(self) -> Dict[str, Dict[str, Dict[str, Any]]]:
+        """Dump all modules and information about them in a JSON serializable dict."""
+        dump: Dict[str, Dict[str, Dict[str, Any]]] = {}
+        for address_conn in self.address_conns.values():
+            seg = f"{address_conn.addr.seg_id:d}"
+            addr = f"{address_conn.addr.addr_id}"
+            if seg not in dump:
+                dump[seg] = {}
+            dump[seg][addr] = address_conn.dump_details()
+        return dump
+
     async def scan_modules(self, num_tries: int = 3, timeout_msec: int = 3000) -> None:
         """Scan for modules on the bus.
 

--- a/pypck/module.py
+++ b/pypck/module.py
@@ -958,6 +958,31 @@ class ModuleConnection(AbstractConnection):
         for input_callback in self.input_callbacks:
             input_callback(inp)
 
+    def dump_details(self) -> Dict[str, Any]:
+        """Dump detailed information about this module."""
+        is_local_segment = (
+            self.addr.seg_id == 0 or self.addr.seg_id == self.conn.local_seg_id
+        )
+        return {
+            "segment": self.addr.seg_id,
+            "address": self.addr.addr_id,
+            "is_local_segment": is_local_segment,
+            "serials": {
+                "hardware_serial": f"{self.hardware_serial:10X}",
+                "manu": f"{self.manu:02X}",
+                "software_serial": f"{self.software_serial:06X}",
+                "hardware_type": f"{self.hardware_type.value:d}",
+                "hardware_name": self.hardware_type.description,
+            },
+            "name": self.name,
+            "comment": self.comment,
+            "oem_text": self.oem_text,
+            "groups": {
+                "static": sorted(addr.addr_id for addr in self.static_groups),
+                "dynamic": sorted(addr.addr_id for addr in self.dynamic_groups),
+            },
+        }
+
     # ##
     # ## Requests
     # ##


### PR DESCRIPTION
The available information for all modules is dumped in a hierarchical dict. The dumping format is json/yaml compatible (only dict, list, str, numbers) and intended to be both human and machine readable.