### PR TITLE
Add a task registry for proper cancelling of all pending tasks

### DIFF
--- a/pypck/__init__.py
+++ b/pypck/__init__.py
@@ -13,9 +13,9 @@ Contributors:
   Andre Lengwenus - port to Python and further improvements
   Tobias Juettner - initial LCN binding for openHAB (Java)
 """
-
 from pypck import (
     connection,
+    helpers,
     inputs,
     lcn_addr,
     lcn_defs,
@@ -27,6 +27,7 @@ from pypck import (
 __all__ = [
     "connection",
     "inputs",
+    "helpers",
     "lcn_addr",
     "lcn_defs",
     "module",

--- a/pypck/helpers.py
+++ b/pypck/helpers.py
@@ -1,0 +1,33 @@
+"""Helper functions for pypck."""
+
+import asyncio
+from typing import Any, Awaitable, List
+
+PYPCK_TASKS: List["asyncio.Task[Any]"] = []
+
+
+def create_task(coro: Awaitable[Any]) -> "asyncio.Task[None]":
+    """Create a task and store a reference in the task registry."""
+    task = asyncio.create_task(coro)
+    task.add_done_callback(PYPCK_TASKS.remove)
+    PYPCK_TASKS.append(task)
+    return task
+
+
+async def cancel_task(task: "asyncio.Task[Any]") -> bool:
+    """Cancel a task.
+
+    Wait for cancellation completed but do not propagate a possible CancelledError.
+    """
+    success = task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    return success  # was not already done
+
+
+async def cancel_all_tasks() -> None:
+    """Cancel all pypck tasks."""
+    for task in tuple(PYPCK_TASKS):
+        await cancel_task(task)

--- a/pypck/module.py
+++ b/pypck/module.py
@@ -30,6 +30,7 @@ from typing import (
 )
 
 from pypck import inputs, lcn_defs
+from pypck.helpers import create_task
 from pypck.lcn_addr import LcnAddr
 from pypck.pck_commands import PckGenerator
 from pypck.request_handlers import (
@@ -833,9 +834,7 @@ class ModuleConnection(AbstractConnection):
 
         self.status_requests_handler = StatusRequestsHandler(self)
         if self.activate_status_requests:
-            self.activate_srh_task = asyncio.create_task(
-                self.activate_status_request_handlers()
-            )
+            create_task(self.activate_status_request_handlers())
 
     async def send_command(self, wants_ack: bool, pck: Union[str, bytes]) -> bool:
         """Send a command to the module represented by this class.
@@ -888,18 +887,17 @@ class ModuleConnection(AbstractConnection):
 
     async def activate_status_request_handler(self, item: Any) -> None:
         """Activate a specific TimeoutRetryHandler for status requests."""
-        await self.status_requests_handler.activate(item)
+        create_task(self.status_requests_handler.activate(item))
 
     async def activate_status_request_handlers(self) -> None:
         """Activate all TimeoutRetryHandlers for status requests."""
-        await self.status_requests_handler.activate_all(activate_s0=self.has_s0_enabled)
+        create_task(
+            self.status_requests_handler.activate_all(activate_s0=self.has_s0_enabled)
+        )
 
     async def cancel_status_request_handler(self, item: Any) -> None:
         """Cancel a specific TimeoutRetryHandler for status requests."""
         await self.status_requests_handler.cancel(item)
-        if self.activate_status_requests:
-            self.activate_srh_task.cancel()
-            await self.activate_srh_task
 
     async def cancel_status_request_handlers(self) -> None:
         """Canecl all TimeoutRetryHandlers for status requests."""

--- a/pypck/request_handlers.py
+++ b/pypck/request_handlers.py
@@ -17,6 +17,7 @@ import asyncio
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union
 
 from pypck import inputs, lcn_defs
+from pypck.helpers import create_task
 from pypck.lcn_addr import LcnAddr
 from pypck.pck_commands import PckGenerator
 from pypck.timeout_retry import TimeoutRetryHandler
@@ -49,7 +50,7 @@ class RequestHandler:
 
     def process_input(self, inp: inputs.Input) -> None:
         """Create a task to process the input object concurrently."""
-        asyncio.create_task(self.async_process_input(inp))
+        create_task(self.async_process_input(inp))
 
     async def async_process_input(self, inp: inputs.Input) -> None:
         """Process incoming input object.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,12 @@
 
 import asyncio
 from typing import Any, AsyncGenerator, List
+
 import pytest
 from pypck.connection import PchkConnectionManager
-from pypck.module import ModuleConnection
+from pypck.helpers import PYPCK_TASKS
 from pypck.lcn_addr import LcnAddr
+from pypck.module import ModuleConnection
 from pypck.pck_commands import PckGenerator
 
 from .fake_pchk import PchkServer
@@ -73,6 +75,7 @@ async def pypck_client() -> AsyncGenerator[PchkConnectionManager, None]:
     )
     yield pcm
     await pcm.async_close()
+    assert len(PYPCK_TASKS) == 0
 
 
 @pytest.fixture


### PR DESCRIPTION
Pypck relies heavily on Python's asyncio module. To properly close all pending tasks when connection is closed, one has to keep track of all pypck tasks which are scheduled on the event loop.
This PR implements a task registry with a designated `create_task` function which should be used instead of `asyncio.create_task`.