### PR TITLE
Fix ping timeout interval

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
   pull_request: ~
 
 env:
-  CACHE_VERSION: 1
+  CACHE_VERSION: 2
   DEFAULT_PYTHON: 3.8
   PRE_COMMIT_HOME: ~/.cache/pre-commit
 

--- a/pypck/connection.py
+++ b/pypck/connection.py
@@ -225,7 +225,7 @@ class PchkConnectionManager(PchkConnection):
         self.settings = lcn_defs.default_connection_settings
         self.settings.update(settings)
 
-        self.ping_interval = 60 * 10  # seconds
+        self.ping_timeout = self.settings["PING_TIMEOUT"] / 1000  # seconds
         self.ping_counter = 0
 
         self.dim_mode = self.settings["DIM_MODE"]
@@ -577,7 +577,7 @@ class PchkConnectionManager(PchkConnection):
         while not self.writer.is_closing():
             await self.send_command(f"^ping{self.ping_counter:d}", to_host=True)
             self.ping_counter += 1
-            await asyncio.sleep(self.settings["PING_TIMEOUT"])
+            await asyncio.sleep(self.ping_timeout)
 
     async def process_message(self, message: str) -> None:
         """Is called when a new text message is received from the PCHK server.


### PR DESCRIPTION
The ping timeout interval is given as miliseconds in the settings. However pypck treats it a seconds so the timeout is a factor 1000 wrong. This is a fix for that issue.