### PR TITLE
Convert the global PYPCK_TASKS to a connection local TaskRegistry

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,3 +86,29 @@ async def module10(
     module = pypck_client.get_module_conn(lcn_addr)
     yield module
     await module.cancel_requests()
+
+
+@pytest.fixture
+async def pchk_server_2() -> AsyncGenerator[PchkServer, None]:
+    """Create a fake PchkServer and run."""
+    pchk_server = PchkServer(
+        host=HOST, port=PORT + 1, username=USERNAME, password=PASSWORD
+    )
+    await pchk_server.run()
+    yield pchk_server
+    await pchk_server.stop()
+
+
+@pytest.fixture
+async def pypck_client_2() -> AsyncGenerator[PchkConnectionManager, None]:
+    """Create a PchkConnectionManager for testing.
+
+    Create a PchkConnection Manager for testing. Add a received coroutine method
+    which returns if the specified message was received (and processed).
+    """
+    pcm = MockPchkConnectionManager(
+        HOST, PORT + 1, USERNAME, PASSWORD, settings={"SK_NUM_TRIES": 0}
+    )
+    yield pcm
+    await pcm.async_close()
+    assert len(pcm.task_registry.tasks) == 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ from typing import Any, AsyncGenerator, List
 
 import pytest
 from pypck.connection import PchkConnectionManager
-from pypck.helpers import PYPCK_TASKS
 from pypck.lcn_addr import LcnAddr
 from pypck.module import ModuleConnection
 from pypck.pck_commands import PckGenerator
@@ -75,7 +74,7 @@ async def pypck_client() -> AsyncGenerator[PchkConnectionManager, None]:
     )
     yield pcm
     await pcm.async_close()
-    assert len(PYPCK_TASKS) == 0
+    assert len(pcm.task_registry.tasks) == 0
 
 
 @pytest.fixture

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -94,6 +94,25 @@ async def test_connection_lost(pchk_server, pypck_client):
 
 
 @pytest.mark.asyncio
+async def test_multiple_connections(
+    pchk_server, pypck_client, pchk_server_2, pypck_client_2
+):
+    """Test that two independent connections can coexists."""
+    await pypck_client_2.async_connect()
+
+    pypck_client.event_handler = AsyncMock()
+    await pypck_client.async_connect()
+
+    await pchk_server.stop()
+    await pypck_client.wait_closed()
+
+    pypck_client.event_handler.assert_has_awaits([call("connection-lost")])
+
+    assert len(pypck_client.task_registry.tasks) == 0
+    assert len(pypck_client_2.task_registry.tasks) > 0
+
+
+@pytest.mark.asyncio
 async def test_segment_coupler_search(pchk_server, pypck_client):
     """Test segment coupler search."""
     await pypck_client.async_connect()


### PR DESCRIPTION
The global PYPCK_TASKS functionality is factored out into TaskRegistry class. Each PchkConnection gets it's own separate registry. This registry is used for creating all tasks in connection, module, and request_handler modules. So it's now possible to have multiple distinct PchkConnection objects in the same task.

First draft of what the local TaskRegistry could look like. Tests for multiple connections in on process are still TODO.

@alengwenus Please let me know what think about the approach. 