### PR TITLE
Status messages for transmitter, transponder and fingerprint codes

### DIFF
--- a/pypck/inputs.py
+++ b/pypck/inputs.py
@@ -860,7 +860,7 @@ class ModStatusAccessControl(ModInput):
     def __init__(
         self,
         physical_source_addr: LcnAddr,
-        access_type: str,
+        periphery: lcn_defs.AccessControlPeriphery,
         code: str,
         level: Optional[int] = None,
         key: Optional[int] = None,
@@ -868,7 +868,7 @@ class ModStatusAccessControl(ModInput):
     ):
         """Construct ModInput object."""
         super().__init__(physical_source_addr)
-        self.access_type = access_type
+        self.periphery = periphery
         self.code = code
         self.level = level
         self.key = key
@@ -888,15 +888,15 @@ class ModStatusAccessControl(ModInput):
         """
         matcher = PckParser.PATTERN_STATUS_TRANSMITTER.match(data)
         if matcher:
-            access_type = "transmitter"
+            periphery = lcn_defs.AccessControlPeriphery.TRANSMITTER
             addr = LcnAddr(int(matcher.group("seg_id")), int(matcher.group("mod_id")))
             code = (
-                f"{int(matcher.group('code1')):02X}"
-                f"{int(matcher.group('code2')):02X}"
-                f"{int(matcher.group('code3')):02X}"
+                f"{int(matcher.group('code1')):02x}"
+                f"{int(matcher.group('code2')):02x}"
+                f"{int(matcher.group('code3')):02x}"
             )
             level = int(matcher.group("level"))
-            key = int(matcher.group("key"))
+            key = int(matcher.group("key")) - 1
 
             actions = {
                 "011": lcn_defs.KeyAction.HIT,
@@ -905,30 +905,29 @@ class ModStatusAccessControl(ModInput):
             }
 
             action = actions[matcher.group("action")]
-
-            return [ModStatusAccessControl(addr, access_type, code, level, key, action)]
+            return [ModStatusAccessControl(addr, periphery, code, level, key, action)]
 
         matcher = PckParser.PATTERN_STATUS_TRANSPONDER.match(data)
         if matcher:
-            access_type = "transponder"
+            periphery = lcn_defs.AccessControlPeriphery.TRANSPONDER
             addr = LcnAddr(int(matcher.group("seg_id")), int(matcher.group("mod_id")))
             code = (
-                f"{int(matcher.group('code1')):02X}"
-                f"{int(matcher.group('code2')):02X}"
-                f"{int(matcher.group('code3')):02X}"
+                f"{int(matcher.group('code1')):02x}"
+                f"{int(matcher.group('code2')):02x}"
+                f"{int(matcher.group('code3')):02x}"
             )
-            return [ModStatusAccessControl(addr, access_type, code)]
+            return [ModStatusAccessControl(addr, periphery, code)]
 
         matcher = PckParser.PATTERN_STATUS_FINGERPRINT.match(data)
         if matcher:
-            access_type = "fingerprint"
+            periphery = lcn_defs.AccessControlPeriphery.FINGERPRINT
             addr = LcnAddr(int(matcher.group("seg_id")), int(matcher.group("mod_id")))
             code = (
-                f"{int(matcher.group('code1')):02X}"
-                f"{int(matcher.group('code2')):02X}"
-                f"{int(matcher.group('code3')):02X}"
+                f"{int(matcher.group('code1')):02x}"
+                f"{int(matcher.group('code2')):02x}"
+                f"{int(matcher.group('code3')):02x}"
             )
-            return [ModStatusAccessControl(addr, access_type, code)]
+            return [ModStatusAccessControl(addr, periphery, code)]
 
         return None
 

--- a/pypck/lcn_defs.py
+++ b/pypck/lcn_defs.py
@@ -155,6 +155,14 @@ class Key(Enum):
     D8 = 31
 
 
+class KeyAction(Enum):
+    """Action types for LCN keys."""
+
+    HIT = auto()
+    MAKE = auto()
+    BREAK = auto()
+
+
 class OutputPortDimMode(Enum):
     """LCN dimming mode.
 

--- a/pypck/lcn_defs.py
+++ b/pypck/lcn_defs.py
@@ -158,9 +158,9 @@ class Key(Enum):
 class KeyAction(Enum):
     """Action types for LCN keys."""
 
-    HIT = auto()
-    MAKE = auto()
-    BREAK = auto()
+    HIT = "hit"
+    MAKE = "make"
+    BREAK = "break"
 
 
 class OutputPortDimMode(Enum):
@@ -1370,6 +1370,14 @@ def hw_type_new(cls, value):
 
 
 setattr(HardwareType, "__new__", hw_type_new)
+
+
+class AccessControlPeriphery(Enum):
+    """Action types for LCN keys."""
+
+    TRANSMITTER = "transmitter"
+    TRANSPONDER = "transponder"
+    FINGERPRINT = "fingerprint"
 
 
 default_connection_settings: Dict[str, Any] = {

--- a/pypck/pck_commands.py
+++ b/pypck/pck_commands.py
@@ -176,6 +176,25 @@ class PckParser:
         r"(?P<actions>\d{3})(?P<keys>\d{3})"
     )
 
+    # Pattern to parse transmitter status messages.
+    PATTERN_STATUS_TRANSMITTER = re.compile(
+        r"=M(?P<seg_id>\d{3})(?P<mod_id>\d{3})\.ZI"
+        r"(?P<code1>\d{3})(?P<code2>\d{3})(?P<code3>\d{3})"
+        r"0(?P<level>\d)(?P<key>\d)(?P<action>\d{3})"
+    )
+
+    # Pattern to parse transponder status messages.
+    PATTERN_STATUS_TRANSPONDER = re.compile(
+        r"=M(?P<seg_id>\d{3})(?P<mod_id>\d{3})\.ZT"
+        r"(?P<code1>\d{3})(?P<code2>\d{3})(?P<code3>\d{3})"
+    )
+
+    # Pattern to parse fingerprint status messages.
+    PATTERN_STATUS_FINGERPRINT = re.compile(
+        r"=M(?P<seg_id>\d{3})(?P<mod_id>\d{3})\.ZF"
+        r"(?P<code1>\d{3})(?P<code2>\d{3})(?P<code3>\d{3})"
+    )
+
     @staticmethod
     def get_boolean_value(input_byte: int) -> List[bool]:
         """Get boolean representation for the given byte.

--- a/pypck/pck_commands.py
+++ b/pypck/pck_commands.py
@@ -180,7 +180,7 @@ class PckParser:
     PATTERN_STATUS_TRANSMITTER = re.compile(
         r"=M(?P<seg_id>\d{3})(?P<mod_id>\d{3})\.ZI"
         r"(?P<code1>\d{3})(?P<code2>\d{3})(?P<code3>\d{3})"
-        r"0(?P<level>\d)(?P<key>\d)(?P<action>\d{3})"
+        r"(?P<level>\d{2})(?P<key>\d)(?P<action>\d{3})"
     )
 
     # Pattern to parse transponder status messages.

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -9,6 +9,7 @@ from pypck.inputs import (
     ModSendKeysHost,
     ModSk,
     ModSn,
+    ModStatusAccessControl,
     ModStatusBinSensors,
     ModStatusGroups,
     ModStatusKeyLocks,
@@ -21,7 +22,9 @@ from pypck.inputs import (
 )
 from pypck.lcn_addr import LcnAddr
 from pypck.lcn_defs import (
+    AccessControlPeriphery,
     HardwareType,
+    KeyAction,
     LedStatus,
     LogicOpStatus,
     OutputPort,
@@ -141,6 +144,25 @@ MESSAGES = {
             [True, True, True, True, True, True, False, False],
             [False, False, True, True, False, False, True, True],
         ],
+    ),
+    # Status Access Control
+    "=M000010.ZI026043060013011": (
+        ModStatusAccessControl,
+        AccessControlPeriphery.TRANSMITTER,
+        "1a2b3c",
+        1,
+        2,
+        KeyAction.HIT,
+    ),
+    "=M000010.ZT026043060": (
+        ModStatusAccessControl,
+        AccessControlPeriphery.TRANSPONDER,
+        "1a2b3c",
+    ),
+    "=M000010.ZF026043060": (
+        ModStatusAccessControl,
+        AccessControlPeriphery.FINGERPRINT,
+        "1a2b3c",
     ),
     # Status scene outputs
     "=M000010.SZ003025150075100140000033200": (


### PR DESCRIPTION
Add `ModStatusAccessControl` input object for handling status messages for transmitter, transponder and fingerprint codes.
Tests are added as well.