### PR TITLE
Replace all asyncio gather calls with sequential calls

### DIFF
--- a/pypck/module.py
+++ b/pypck/module.py
@@ -634,17 +634,14 @@ class AbstractConnection:
         :rtype:      bool
         """
         encoded_text = text.encode(lcn_defs.LCN_ENCODING)
-        coros = []
         parts = [encoded_text[12 * part : 12 * part + 12] for part in range(5)]
         for part_id, part in enumerate(parts):
-            coros.append(
-                self.send_command(
-                    not self.is_group,
-                    PckGenerator.dyn_text_part(row_id, part_id, part),
-                )
-            )
-        results = await asyncio.gather(*coros)
-        return all(results)
+            if not await self.send_command(
+                not self.is_group,
+                PckGenerator.dyn_text_part(row_id, part_id, part),
+            ):
+                return False
+        return True
 
     async def beep(self, sound: lcn_defs.BeepSound, count: int) -> bool:
         """Send a command to make count number of beep sounds.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md") as fh:
 
 setuptools.setup(
     name="pypck",
-    version="0.7.13",
+    version="0.7.14",
     author="Andre Lengwenus",
     author_email="alengwenus@gmail.com",
     description="LCN-PCK library",

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -253,8 +253,8 @@ async def test_groups_membership_discovery(pchk_server, pypck_client):
 
     task = asyncio.create_task(module.request_groups())
     assert await pchk_server.received(">M000010.GP")
-    assert await pchk_server.received(">M000010.GD")
     await pchk_server.send_message("=M000010.GP012011200051")
+    assert await pchk_server.received(">M000010.GD")
     await pchk_server.send_message("=M000010.GD008015100052")
     assert await task == {
         LcnAddr(0, 11, True),

--- a/tests/test_dyn_text.py
+++ b/tests/test_dyn_text.py
@@ -72,4 +72,4 @@ async def test_dyn_text(pypck_client, text, parts):
     _, commands = zip(*await_args)
 
     for i, part in enumerate(parts):
-        assert (f"GTDT4{i+1:d}".encode() + part) in commands
+        assert f"GTDT4{i+1:d}".encode() + part in commands


### PR DESCRIPTION
When sending several commands concurrently using `asyncio.gather` there might occur race conditions with the acknowledge responses, especially if the PCHK host does not mange it to send the commands to the bus.
All `asyncio.gather` calls have been replaced with sequential calls which one by one are waiting for an acknowledgement.