### PR TITLE
Fix transmitter action code due to battery status

### DIFF
--- a/pypck/inputs.py
+++ b/pypck/inputs.py
@@ -856,6 +856,7 @@ class ModStatusAccessControl(ModInput):
         level: Optional[int] = None,
         key: Optional[int] = None,
         action: Optional[lcn_defs.KeyAction] = None,
+        battery: Optional[lcn_defs.BatteryStatus] = None,
     ):
         """Construct ModInput object."""
         super().__init__(physical_source_addr)
@@ -864,6 +865,7 @@ class ModStatusAccessControl(ModInput):
         self.level = level
         self.key = key
         self.action = action
+        self.battery = battery
 
     @staticmethod
     def try_parse(data: str) -> Optional[List[Input]]:
@@ -890,13 +892,24 @@ class ModStatusAccessControl(ModInput):
             key = int(matcher.group("key")) - 1
 
             actions = {
-                "011": lcn_defs.KeyAction.HIT,
-                "012": lcn_defs.KeyAction.MAKE,
-                "013": lcn_defs.KeyAction.BREAK,
+                "1": lcn_defs.KeyAction.HIT,
+                "2": lcn_defs.KeyAction.MAKE,
+                "3": lcn_defs.KeyAction.BREAK,
             }
 
-            action = actions[matcher.group("action")]
-            return [ModStatusAccessControl(addr, periphery, code, level, key, action)]
+            battery_status = {
+                "0": lcn_defs.BatteryStatus.FULL,
+                "1": lcn_defs.BatteryStatus.WEAK,
+            }
+
+            action = actions[matcher.group("action")[2]]
+            battery = battery_status[matcher.group("action")[1]]
+
+            return [
+                ModStatusAccessControl(
+                    addr, periphery, code, level, key, action, battery
+                )
+            ]
 
         matcher = PckParser.PATTERN_STATUS_TRANSPONDER.match(data)
         if matcher:

--- a/pypck/lcn_defs.py
+++ b/pypck/lcn_defs.py
@@ -149,6 +149,13 @@ class KeyAction(Enum):
     BREAK = "break"
 
 
+class BatteryStatus(Enum):
+    """Battery status."""
+
+    WEAK = "weak"
+    FULL = "full"
+
+
 class OutputPortDimMode(Enum):
     """LCN dimming mode.
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -23,6 +23,7 @@ from pypck.inputs import (
 from pypck.lcn_addr import LcnAddr
 from pypck.lcn_defs import (
     AccessControlPeriphery,
+    BatteryStatus,
     HardwareType,
     KeyAction,
     LedStatus,
@@ -146,6 +147,15 @@ MESSAGES = {
         ],
     ),
     # Status Access Control
+    "=M000010.ZI026043060013002": (
+        ModStatusAccessControl,
+        AccessControlPeriphery.TRANSMITTER,
+        "1a2b3c",
+        1,
+        2,
+        KeyAction.MAKE,
+        BatteryStatus.FULL,
+    ),
     "=M000010.ZI026043060013011": (
         ModStatusAccessControl,
         AccessControlPeriphery.TRANSMITTER,
@@ -153,6 +163,7 @@ MESSAGES = {
         1,
         2,
         KeyAction.HIT,
+        BatteryStatus.WEAK,
     ),
     "=M000010.ZT026043060": (
         ModStatusAccessControl,


### PR DESCRIPTION
Add the battery status to transmitter Input object.
Fix transmitter action code due to battery status.