### PR TITLE
Fix commands for rt600 and rt1200

### DIFF
--- a/pypck/pck_commands.py
+++ b/pypck/pck_commands.py
@@ -586,24 +586,24 @@ class PckGenerator:
         if state == lcn_defs.MotorStateModifier.UP:
             if reverse_time in [None, lcn_defs.MotorReverseTime.RT70]:
                 params = (0x01, 0xE4, 0x00)
+                ret = f"X2{params[0]:03d}{params[1]:03d}{params[2]:03d}"
             elif reverse_time == lcn_defs.MotorReverseTime.RT600:
-                params = (0x04, 0xC8, 0x08)
+                ret = PckGenerator.dim_output(0, 100, 8)
             elif reverse_time == lcn_defs.MotorReverseTime.RT1200:
-                params = (0x04, 0xC8, 0x0B)
+                ret = PckGenerator.dim_output(0, 100, 11)
             else:
                 raise ValueError("Wrong MotorReverseTime.")
-            ret = f"X2{params[0]:03d}{params[1]:03d}{params[2]:03d}"
 
         elif state == lcn_defs.MotorStateModifier.DOWN:
             if reverse_time in [None, lcn_defs.MotorReverseTime.RT70]:
                 params = (0x01, 0x00, 0xE4)
+                ret = f"X2{params[0]:03d}{params[1]:03d}{params[2]:03d}"
             elif reverse_time == lcn_defs.MotorReverseTime.RT600:
-                params = (0x05, 0xC8, 0x08)
+                ret = PckGenerator.dim_output(1, 100, 8)
             elif reverse_time == lcn_defs.MotorReverseTime.RT1200:
-                params = (0x05, 0xC8, 0x0B)
+                ret = PckGenerator.dim_output(1, 100, 11)
             else:
                 raise ValueError("Wrong MotorReverseTime.")
-            ret = f"X2{params[0]:03d}{params[1]:03d}{params[2]:03d}"
 
         elif state == lcn_defs.MotorStateModifier.STOP:
             ret = "AY000000"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,6 +1,7 @@
 """Tests for command generation directed at bus modules and groups."""
 
 import pytest
+
 from pypck.lcn_addr import LcnAddr
 from pypck.lcn_defs import (
     BeepSound,
@@ -215,12 +216,12 @@ COMMANDS = {
         MotorStateModifier.UP,
         MotorReverseTime.RT70,
     ),
-    "X2004200008": (
+    "A1DI100008": (
         PckGenerator.control_motors_outputs,
         MotorStateModifier.UP,
         MotorReverseTime.RT600,
     ),
-    "X2004200011": (
+    "A1DI100011": (
         PckGenerator.control_motors_outputs,
         MotorStateModifier.UP,
         MotorReverseTime.RT1200,
@@ -230,12 +231,12 @@ COMMANDS = {
         MotorStateModifier.DOWN,
         MotorReverseTime.RT70,
     ),
-    "X2005200008": (
+    "A2DI100008": (
         PckGenerator.control_motors_outputs,
         MotorStateModifier.DOWN,
         MotorReverseTime.RT600,
     ),
-    "X2005200011": (
+    "A2DI100011": (
         PckGenerator.control_motors_outputs,
         MotorStateModifier.DOWN,
         MotorReverseTime.RT1200,


### PR DESCRIPTION
An issue with the output covers was reported in https://community.home-assistant.io/t/lcn-with-output-shutters/729746.
The problem only occurs if the installation is configured to 50 dim steps.
This PR is a fix to that issue.