### PR TITLE
Synched command sending based on message traffic

### DIFF
--- a/pypck/lcn_defs.py
+++ b/pypck/lcn_defs.py
@@ -1402,4 +1402,5 @@ default_connection_settings: dict[str, Any] = {
     # been send which
     # potentially changed
     # that status.
+    "BUS_IDLE_TIME": 0.05,  # Time to wait for message traffic before sending.
 }

--- a/pypck/timeout_retry.py
+++ b/pypck/timeout_retry.py
@@ -69,13 +69,16 @@ class TimeoutRetryHandler:
     async def async_activate(self) -> None:
         """Clean start of next timeout_loop."""
         if self.is_active():
-            await self.cancel()
+            return
         self.timeout_loop_task = self.task_registry.create_task(self.timeout_loop())
 
     async def done(self) -> None:
         """Signal the completion of the TimeoutRetryHandler."""
         if self.timeout_loop_task is not None:
-            await self.timeout_loop_task
+            try:
+                await self.timeout_loop_task
+            except asyncio.CancelledError:
+                pass
 
     async def cancel(self) -> None:
         """Must be called when a response (requested or not) is received."""


### PR DESCRIPTION
Add a message FIFO buffer to PchkConnection.
Message traffic (incoming and outgoing) is observed and only new commands are sent if  the message traffic is idle for a certain time. This should reduce telegram collisions if the LCN coupler hardware cannot handle this on its own.
Reduce message traffic for status requests the first time the RequestHandlers are set up.