### PR TITLE
Add await writer.drain() after writer.write() for proper flow control

### DIFF
--- a/tests/mock_pchk.py
+++ b/tests/mock_pchk.py
@@ -129,6 +129,7 @@ class MockPchkServer:
 
         if self.license_error:
             self.writer.write(b"$err:(license?)" + self.separator)
+            await self.writer.drain()
             return False
 
         return True
@@ -158,6 +159,7 @@ class MockPchkServer:
         """Send the given message to the socket."""
         assert self.writer is not None
         self.writer.write(message.encode() + self.separator)
+        await self.writer.drain()
 
     async def received(
         self, message: bytes | str, timeout: int = 5, remove: bool = True


### PR DESCRIPTION
### Summary

This PR adds `await writer.drain()` after `writer.write()` calls to ensure proper flow control and prevent potential data loss or write buffer overflows when interacting with `asyncio` streams.

### Rationale

According to the [Python asyncio documentation](https://docs.python.org/3.10/library/asyncio-stream.html#asyncio.StreamWriter.write), `writer.write()` only queues data, and it’s necessary to call await `writer.drain()` to ensure the data is properly written when the internal buffer is full. The `drain()` method blocks when the buffer is full, preventing overflows and ensuring all data is transmitted before continuing execution. Without this, there is a risk of data not being fully sent or written.

This change ensures the write buffer is correctly managed, especially in cases of high-volume or rapid write operations, maintaining stream reliability and preventing potential issues in production environments.