### PR TITLE
Fix read- and writeloop

### DIFF
--- a/pypck/connection.py
+++ b/pypck/connection.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections import deque
 from collections.abc import Awaitable, Callable, Iterable
 from types import TracebackType
 from typing import Any
@@ -82,7 +81,7 @@ class PchkConnection:
         self.connection_id = connection_id
         self.reader: asyncio.StreamReader | None = None
         self.writer: asyncio.StreamWriter | None = None
-        self.buffer: deque[bytes] = deque()
+        self.buffer: asyncio.Queue[bytes] = asyncio.Queue()
         self.idle_time = 0.05
         self.last_bus_activity = time.time()
         self.event_handler: Callable[[str], Awaitable[None]] = (
@@ -138,13 +137,9 @@ class PchkConnection:
         assert self.writer is not None
         try:
             while not self.writer.is_closing():
-                await asyncio.sleep(self.idle_time)
-                if len(self.buffer) == 0:
-                    continue
-                if time.time() - self.last_bus_activity < self.idle_time:
-                    continue
-                data = self.buffer.popleft()
-                self.last_bus_activity = time.time()
+                data = await self.buffer.get()
+                while (time.time() - self.last_bus_activity) < self.idle_time:
+                    await asyncio.sleep(self.idle_time)
 
                 _LOGGER.debug(
                     "to %s: %s",
@@ -153,8 +148,13 @@ class PchkConnection:
                 )
                 self.writer.write(data)
                 await self.writer.drain()
+                self.last_bus_activity = time.time()
         except asyncio.CancelledError:
-            self.buffer.clear()
+            pass
+
+        # empty the queue
+        while not self.buffer.empty():
+            await self.buffer.get()
 
     async def send_command(self, pck: bytes | str, **kwargs: Any) -> bool:
         """Send a PCK command to the PCHK server.
@@ -167,7 +167,7 @@ class PchkConnection:
                 data = (pck + PckGenerator.TERMINATION).encode()
             else:
                 data = pck + PckGenerator.TERMINATION.encode()
-            self.buffer.append(data)
+            await self.buffer.put(data)
             return True
         return False
 


### PR DESCRIPTION
Raising an `asyncio.CancelledError` in the read- and write-data loops (e.g., when closing the connection) could led to an unproper handling of this exception.

In addition the `collections.deque` is replaced by `asyncio.Queue` which reduces the while loop iterations in the `write_data_loop`.