### PR TITLE
More relaxing handling of module's manufacturer code.

### DIFF
--- a/pypck/inputs.py
+++ b/pypck/inputs.py
@@ -392,7 +392,17 @@ class ModSn(ModInput):
         if matcher:
             addr = LcnAddr(int(matcher.group("seg_id")), int(matcher.group("mod_id")))
             hardware_serial = int(matcher.group("hardware_serial"), 16)
-            manu = int(matcher.group("manu"), 16)
+            try:
+                manu = int(matcher.group("manu"), 16)
+            except (
+                ValueError
+            ):  # unconventional manufacturer code (e.g., due to LinHK VM)
+                manu = 0xFF
+                _LOGGER.debug(
+                    "Unconventional manufacturer code: %s. Defaulting to 0x%02X",
+                    matcher.group("manu"),
+                    manu,
+                )
             software_serial = int(matcher.group("software_serial"), 16)
             try:
                 hardware_type = lcn_defs.HardwareType(

--- a/pypck/pck_commands.py
+++ b/pypck/pck_commands.py
@@ -60,7 +60,7 @@ class PckParser:
     # Pattern to parse serial number and firmware date responses.
     PATTERN_SN = re.compile(
         r"=M(?P<seg_id>\d{3})(?P<mod_id>\d{3})\.SN(?P<hardware_serial>[0-9|A-F]{10})"
-        r"(?P<manu>[0-9|A-F]{2})FW(?P<software_serial>[0-9|A-F]{6})"
+        r"(?P<manu>.{2})FW(?P<software_serial>[0-9|A-F]{6})"
         r"HW(?P<hardware_type>\d+)"
     )
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -56,6 +56,13 @@ MESSAGES = {
         0x190011,
         HardwareType.UPP,
     ),
+    "=M000010.SN1234567890vMFW190011HW011": (
+        ModSn,
+        0x1234567890,
+        0xFF,
+        0x190011,
+        HardwareType.UPP,
+    ),
     # Name
     "=M000010.N1EG HWR Hau": (ModNameComment, "N", 0, "EG HWR Hau"),
     "=M000010.N2EG HWR Hau": (ModNameComment, "N", 1, "EG HWR Hau"),


### PR DESCRIPTION
The second part of a module's serial numbers request contains the hexadecimal string representation of one byte value (0x00-0xFF). This is defined as `manufacturer code` in pypck.
It has been observed that the LinHK software returns the string "vM" for virtual modules. This is not a hexadecimal string representation of any value and therefore cannot be converted according to the PCHK "standard".
The parsing for the serial number response message is more relaxing now, In case of a not convertable string, the default value 0xFF is returned and the incident is logged.