### PR TITLE
Add decoding workaround for LinHK

### DIFF
--- a/pypck/connection.py
+++ b/pypck/connection.py
@@ -164,12 +164,22 @@ class PchkConnectionManager:
                     break
 
                 try:
-                    message = data.decode().split(PckGenerator.TERMINATION)[0]
+                    message = data.decode("utf-8").split(PckGenerator.TERMINATION)[0]
                 except UnicodeDecodeError as err:
-                    _LOGGER.warning(
-                        "PCK decoding error: %s - skipping received PCK message", err
-                    )
-                    continue
+                    try:
+                        message = data.decode("cp1250").split(PckGenerator.TERMINATION)[
+                            0
+                        ]
+                        _LOGGER.warning(
+                            "Incorrect PCK encoding detected, possibly caused by LinHK: %s - PCK recovered using cp1250",
+                            err,
+                        )
+                    except UnicodeDecodeError as err2:
+                        _LOGGER.warning(
+                            "PCK decoding error: %s - skipping received PCK message",
+                            err2,
+                        )
+                        continue
                 await self.process_message(message)
         except asyncio.CancelledError:
             pass


### PR DESCRIPTION
PCHK uses `utf-8` for PCK encoding. Because LinHK uses Windows-1250 (`cp1250`) to encode PCK messages this results in decocding errors if special characters are used (e.g., for module names).
This PR implements a fallback decoding to `cp1250` in case `utf-8` fails.